### PR TITLE
feat: add missing MCP tools for notes API parity

### DIFF
--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -31,7 +31,9 @@ pub fn create_router(state: OrchestratorState) -> Router {
         )
         .route(
             "/api/projects/{slug}",
-            get(project_handlers::get_project).delete(project_handlers::delete_project),
+            get(project_handlers::get_project)
+                .patch(project_handlers::update_project)
+                .delete(project_handlers::delete_project),
         )
         .route(
             "/api/projects/{slug}/sync",
@@ -96,7 +98,9 @@ pub fn create_router(state: OrchestratorState) -> Router {
         )
         .route(
             "/api/constraints/{constraint_id}",
-            axum::routing::delete(handlers::delete_constraint),
+            get(handlers::get_constraint)
+                .patch(handlers::update_constraint)
+                .delete(handlers::delete_constraint),
         )
         // Tasks (global listing)
         .route("/api/tasks", get(handlers::list_all_tasks))
@@ -104,7 +108,9 @@ pub fn create_router(state: OrchestratorState) -> Router {
         .route("/api/plans/{plan_id}/tasks", post(handlers::add_task))
         .route(
             "/api/tasks/{task_id}",
-            get(handlers::get_task).patch(handlers::update_task),
+            get(handlers::get_task)
+                .patch(handlers::update_task)
+                .delete(handlers::delete_task),
         )
         // Task dependencies
         .route(
@@ -134,7 +140,9 @@ pub fn create_router(state: OrchestratorState) -> Router {
         )
         .route(
             "/api/steps/{step_id}",
-            axum::routing::patch(handlers::update_step),
+            get(handlers::get_step)
+                .patch(handlers::update_step)
+                .delete(handlers::delete_step),
         )
         // Context
         .route(
@@ -150,13 +158,21 @@ pub fn create_router(state: OrchestratorState) -> Router {
             "/api/tasks/{task_id}/decisions",
             post(handlers::add_decision),
         )
+        .route(
+            "/api/decisions/{decision_id}",
+            get(handlers::get_decision)
+                .patch(handlers::update_decision)
+                .delete(handlers::delete_decision),
+        )
         .route("/api/decisions/search", get(handlers::search_decisions))
         // Sync
         .route("/api/sync", post(handlers::sync_directory))
         // Releases
         .route(
             "/api/releases/{release_id}",
-            get(handlers::get_release).patch(handlers::update_release),
+            get(handlers::get_release)
+                .patch(handlers::update_release)
+                .delete(handlers::delete_release),
         )
         .route(
             "/api/releases/{release_id}/tasks",
@@ -169,7 +185,9 @@ pub fn create_router(state: OrchestratorState) -> Router {
         // Milestones
         .route(
             "/api/milestones/{milestone_id}",
-            get(handlers::get_milestone).patch(handlers::update_milestone),
+            get(handlers::get_milestone)
+                .patch(handlers::update_milestone)
+                .delete(handlers::delete_milestone),
         )
         .route(
             "/api/milestones/{milestone_id}/tasks",
@@ -367,7 +385,9 @@ pub fn create_router(state: OrchestratorState) -> Router {
         )
         .route(
             "/api/resources/{id}",
-            get(workspace_handlers::get_resource).delete(workspace_handlers::delete_resource),
+            get(workspace_handlers::get_resource)
+                .patch(workspace_handlers::update_resource)
+                .delete(workspace_handlers::delete_resource),
         )
         .route(
             "/api/resources/{id}/projects",
@@ -380,7 +400,9 @@ pub fn create_router(state: OrchestratorState) -> Router {
         )
         .route(
             "/api/components/{id}",
-            get(workspace_handlers::get_component).delete(workspace_handlers::delete_component),
+            get(workspace_handlers::get_component)
+                .patch(workspace_handlers::update_component)
+                .delete(workspace_handlers::delete_component),
         )
         .route(
             "/api/components/{id}/dependencies",

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -45,6 +45,8 @@ impl ToolHandler {
             "get_project_roadmap" => self.get_project_roadmap(args).await,
             "list_project_plans" => self.list_project_plans(args).await,
 
+            "update_project" => self.update_project(args).await,
+
             // Plans
             "list_plans" => self.list_plans(args).await,
             "create_plan" => self.create_plan(args).await,
@@ -61,6 +63,7 @@ impl ToolHandler {
             "create_task" => self.create_task(args).await,
             "get_task" => self.get_task(args).await,
             "update_task" => self.update_task(args).await,
+            "delete_task" => self.delete_task(args).await,
             "get_next_task" => self.get_next_task(args).await,
             "add_task_dependencies" => self.add_task_dependencies(args).await,
             "remove_task_dependency" => self.remove_task_dependency(args).await,
@@ -73,12 +76,16 @@ impl ToolHandler {
             // Steps
             "list_steps" => self.list_steps(args).await,
             "create_step" => self.create_step(args).await,
+            "get_step" => self.get_step(args).await,
+            "delete_step" => self.delete_step_handler(args).await,
             "update_step" => self.update_step(args).await,
             "get_step_progress" => self.get_step_progress(args).await,
 
             // Constraints
             "list_constraints" => self.list_constraints(args).await,
             "add_constraint" => self.add_constraint(args).await,
+            "get_constraint" => self.get_constraint(args).await,
+            "update_constraint" => self.update_constraint(args).await,
             "delete_constraint" => self.delete_constraint(args).await,
 
             // Releases
@@ -86,6 +93,7 @@ impl ToolHandler {
             "create_release" => self.create_release(args).await,
             "get_release" => self.get_release(args).await,
             "update_release" => self.update_release(args).await,
+            "delete_release" => self.delete_release(args).await,
             "add_task_to_release" => self.add_task_to_release(args).await,
             "add_commit_to_release" => self.add_commit_to_release(args).await,
 
@@ -94,6 +102,7 @@ impl ToolHandler {
             "create_milestone" => self.create_milestone(args).await,
             "get_milestone" => self.get_milestone(args).await,
             "update_milestone" => self.update_milestone(args).await,
+            "delete_milestone" => self.delete_milestone(args).await,
             "get_milestone_progress" => self.get_milestone_progress(args).await,
             "add_task_to_milestone" => self.add_task_to_milestone(args).await,
 
@@ -119,6 +128,9 @@ impl ToolHandler {
             "get_impl_blocks" => self.get_impl_blocks(args).await,
 
             // Decisions
+            "get_decision" => self.get_decision(args).await,
+            "update_decision" => self.update_decision(args).await,
+            "delete_decision" => self.delete_decision(args).await,
             "search_decisions" => self.search_decisions(args).await,
 
             // Sync
@@ -174,6 +186,7 @@ impl ToolHandler {
             "list_resources" => self.list_resources(args).await,
             "create_resource" => self.create_resource(args).await,
             "get_resource" => self.get_resource(args).await,
+            "update_resource" => self.update_resource(args).await,
             "delete_resource" => self.delete_resource(args).await,
             "link_resource_to_project" => self.link_resource_to_project(args).await,
 
@@ -181,6 +194,7 @@ impl ToolHandler {
             "list_components" => self.list_components(args).await,
             "create_component" => self.create_component(args).await,
             "get_component" => self.get_component(args).await,
+            "update_component" => self.update_component(args).await,
             "delete_component" => self.delete_component(args).await,
             "add_component_dependency" => self.add_component_dependency(args).await,
             "remove_component_dependency" => self.remove_component_dependency(args).await,
@@ -261,6 +275,36 @@ impl ToolHandler {
             .ok_or_else(|| anyhow!("Project not found: {}", slug))?;
 
         Ok(serde_json::to_value(project)?)
+    }
+
+    async fn update_project(&self, args: Value) -> Result<Value> {
+        let slug = args
+            .get("slug")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("slug is required"))?;
+
+        let project = self
+            .neo4j()
+            .get_project_by_slug(slug)
+            .await?
+            .ok_or_else(|| anyhow!("Project not found: {}", slug))?;
+
+        let name = args
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let description = args
+            .get("description")
+            .map(|v| v.as_str().map(|s| s.to_string()));
+        let root_path = args
+            .get("root_path")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        self.neo4j()
+            .update_project(project.id, name, description, root_path)
+            .await?;
+        Ok(json!({"updated": true}))
     }
 
     async fn delete_project(&self, args: Value) -> Result<Value> {
@@ -746,6 +790,15 @@ impl ToolHandler {
             .ok_or_else(|| anyhow!("Task not found"))?;
 
         Ok(serde_json::to_value(details)?)
+    }
+
+    async fn delete_task(&self, args: Value) -> Result<Value> {
+        let task_id = parse_uuid(&args, "task_id")?;
+        self.orchestrator
+            .plan_manager()
+            .delete_task(task_id)
+            .await?;
+        Ok(json!({"deleted": true}))
     }
 
     async fn update_task(&self, args: Value) -> Result<Value> {
@@ -2198,7 +2251,10 @@ impl ToolHandler {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow!("entity_id is required"))?;
         let max_depth = args.get("max_depth").and_then(|v| v.as_u64()).unwrap_or(3) as u32;
-        let min_score = args.get("min_score").and_then(|v| v.as_f64()).unwrap_or(0.1);
+        let min_score = args
+            .get("min_score")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.1);
 
         let entity_type: crate::notes::EntityType = entity_type_str
             .parse()
@@ -2981,6 +3037,163 @@ impl ToolHandler {
         let topology = self.neo4j().get_workspace_topology(workspace.id).await?;
         Ok(serde_json::to_value(topology)?)
     }
+
+    // ========================================================================
+    // Additional CRUD Handlers (get_step, delete_step, decisions, constraints,
+    // delete_release, delete_milestone, update_resource, update_component)
+    // ========================================================================
+
+    async fn get_step(&self, args: Value) -> Result<Value> {
+        let step_id = parse_uuid(&args, "step_id")?;
+        let step = self
+            .neo4j()
+            .get_step(step_id)
+            .await?
+            .ok_or_else(|| anyhow!("Step not found"))?;
+        Ok(serde_json::to_value(step)?)
+    }
+
+    async fn delete_step_handler(&self, args: Value) -> Result<Value> {
+        let step_id = parse_uuid(&args, "step_id")?;
+        self.neo4j().delete_step(step_id).await?;
+        Ok(json!({"deleted": true}))
+    }
+
+    async fn get_constraint(&self, args: Value) -> Result<Value> {
+        let constraint_id = parse_uuid(&args, "constraint_id")?;
+        let constraint = self
+            .neo4j()
+            .get_constraint(constraint_id)
+            .await?
+            .ok_or_else(|| anyhow!("Constraint not found"))?;
+        Ok(serde_json::to_value(constraint)?)
+    }
+
+    async fn update_constraint(&self, args: Value) -> Result<Value> {
+        let constraint_id = parse_uuid(&args, "constraint_id")?;
+        let description = args
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let constraint_type = args
+            .get("constraint_type")
+            .and_then(|v| v.as_str())
+            .and_then(|s| serde_json::from_str(&format!("\"{}\"", s)).ok());
+        let enforced_by = args
+            .get("enforced_by")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        self.neo4j()
+            .update_constraint(constraint_id, description, constraint_type, enforced_by)
+            .await?;
+        Ok(json!({"updated": true}))
+    }
+
+    async fn delete_release(&self, args: Value) -> Result<Value> {
+        let release_id = parse_uuid(&args, "release_id")?;
+        self.neo4j().delete_release(release_id).await?;
+        Ok(json!({"deleted": true}))
+    }
+
+    async fn delete_milestone(&self, args: Value) -> Result<Value> {
+        let milestone_id = parse_uuid(&args, "milestone_id")?;
+        self.neo4j().delete_milestone(milestone_id).await?;
+        Ok(json!({"deleted": true}))
+    }
+
+    async fn get_decision(&self, args: Value) -> Result<Value> {
+        let decision_id = parse_uuid(&args, "decision_id")?;
+        let decision = self
+            .neo4j()
+            .get_decision(decision_id)
+            .await?
+            .ok_or_else(|| anyhow!("Decision not found"))?;
+        Ok(serde_json::to_value(decision)?)
+    }
+
+    async fn update_decision(&self, args: Value) -> Result<Value> {
+        let decision_id = parse_uuid(&args, "decision_id")?;
+        let description = args
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let rationale = args
+            .get("rationale")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let chosen_option = args
+            .get("chosen_option")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        self.neo4j()
+            .update_decision(decision_id, description, rationale, chosen_option)
+            .await?;
+        Ok(json!({"updated": true}))
+    }
+
+    async fn delete_decision(&self, args: Value) -> Result<Value> {
+        let decision_id = parse_uuid(&args, "decision_id")?;
+        self.neo4j().delete_decision(decision_id).await?;
+        Ok(json!({"deleted": true}))
+    }
+
+    async fn update_resource(&self, args: Value) -> Result<Value> {
+        let id = parse_uuid(&args, "id")?;
+        let name = args
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let file_path = args
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let url = args
+            .get("url")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let version = args
+            .get("version")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let description = args
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        self.neo4j()
+            .update_resource(id, name, file_path, url, version, description)
+            .await?;
+        Ok(json!({"updated": true}))
+    }
+
+    async fn update_component(&self, args: Value) -> Result<Value> {
+        let id = parse_uuid(&args, "id")?;
+        let name = args
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let description = args
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let runtime = args
+            .get("runtime")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let config = args.get("config").cloned();
+        let tags: Option<Vec<String>> = args.get("tags").and_then(|v| v.as_array()).map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        });
+
+        self.neo4j()
+            .update_component(id, name, description, runtime, config, tags)
+            .await?;
+        Ok(json!({"updated": true}))
+    }
 }
 
 // ============================================================================
@@ -3701,5 +3914,269 @@ mod tests {
 
         // Only strings are extracted
         assert_eq!(tags, vec!["valid", "another"]);
+    }
+
+    // ========================================================================
+    // New CRUD handler arg extraction tests
+    // ========================================================================
+
+    #[test]
+    fn test_update_project_args_extraction() {
+        let args = json!({
+            "slug": "my-project",
+            "name": "New Name",
+            "description": "New desc",
+            "root_path": "/new/path"
+        });
+
+        let slug = args.get("slug").and_then(|v| v.as_str());
+        assert_eq!(slug, Some("my-project"));
+
+        let name = args
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert_eq!(name, Some("New Name".to_string()));
+
+        let description = args
+            .get("description")
+            .map(|v| v.as_str().map(|s| s.to_string()));
+        assert_eq!(description, Some(Some("New desc".to_string())));
+
+        let root_path = args
+            .get("root_path")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert_eq!(root_path, Some("/new/path".to_string()));
+    }
+
+    #[test]
+    fn test_update_project_args_partial() {
+        // Only slug, all others missing
+        let args = json!({"slug": "my-project"});
+
+        let name = args
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert_eq!(name, None);
+
+        let description = args
+            .get("description")
+            .map(|v| v.as_str().map(|s| s.to_string()));
+        assert_eq!(description, None);
+
+        let root_path = args
+            .get("root_path")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert_eq!(root_path, None);
+    }
+
+    #[test]
+    fn test_update_project_args_null_description() {
+        // Explicit null description (to clear it)
+        let args = json!({
+            "slug": "my-project",
+            "description": null
+        });
+
+        let description = args
+            .get("description")
+            .map(|v| v.as_str().map(|s| s.to_string()));
+        // description key exists but value is null -> Some(None)
+        assert_eq!(description, Some(None));
+    }
+
+    #[test]
+    fn test_update_constraint_args_with_enum() {
+        let args = json!({
+            "constraint_id": "550e8400-e29b-41d4-a716-446655440000",
+            "description": "Must be fast",
+            "constraint_type": "performance",
+            "enforced_by": "benchmark"
+        });
+
+        let constraint_id = parse_uuid(&args, "constraint_id");
+        assert!(constraint_id.is_ok());
+
+        let constraint_type: Option<crate::neo4j::models::ConstraintType> = args
+            .get("constraint_type")
+            .and_then(|v| v.as_str())
+            .and_then(|s| serde_json::from_str(&format!("\"{}\"", s)).ok());
+        assert!(constraint_type.is_some());
+
+        let enforced_by = args
+            .get("enforced_by")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert_eq!(enforced_by, Some("benchmark".to_string()));
+    }
+
+    #[test]
+    fn test_update_constraint_args_invalid_enum() {
+        let args = json!({
+            "constraint_id": "550e8400-e29b-41d4-a716-446655440000",
+            "constraint_type": "invalid_type"
+        });
+
+        let constraint_type: Option<crate::neo4j::models::ConstraintType> = args
+            .get("constraint_type")
+            .and_then(|v| v.as_str())
+            .and_then(|s| serde_json::from_str(&format!("\"{}\"", s)).ok());
+        // Invalid enum variant -> None (graceful)
+        assert!(constraint_type.is_none());
+    }
+
+    #[test]
+    fn test_update_decision_args_extraction() {
+        let args = json!({
+            "decision_id": "550e8400-e29b-41d4-a716-446655440000",
+            "description": "Updated desc",
+            "rationale": "New rationale",
+            "chosen_option": "Option B"
+        });
+
+        let decision_id = parse_uuid(&args, "decision_id");
+        assert!(decision_id.is_ok());
+
+        let description = args
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert_eq!(description, Some("Updated desc".to_string()));
+
+        let rationale = args
+            .get("rationale")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert_eq!(rationale, Some("New rationale".to_string()));
+
+        let chosen_option = args
+            .get("chosen_option")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert_eq!(chosen_option, Some("Option B".to_string()));
+    }
+
+    #[test]
+    fn test_update_resource_args_extraction() {
+        let args = json!({
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "name": "API v2",
+            "file_path": "/api/v2.yaml",
+            "url": "https://example.com/api",
+            "version": "2.0.0",
+            "description": "Updated API contract"
+        });
+
+        let id = parse_uuid(&args, "id");
+        assert!(id.is_ok());
+
+        let name = args
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert_eq!(name, Some("API v2".to_string()));
+
+        let url = args
+            .get("url")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert_eq!(url, Some("https://example.com/api".to_string()));
+
+        let version = args
+            .get("version")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert_eq!(version, Some("2.0.0".to_string()));
+    }
+
+    #[test]
+    fn test_update_component_args_with_config_and_tags() {
+        let args = json!({
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "name": "Auth Service",
+            "runtime": "rust",
+            "config": {"port": 8080, "workers": 4},
+            "tags": ["auth", "core", "security"]
+        });
+
+        let id = parse_uuid(&args, "id");
+        assert!(id.is_ok());
+
+        let config = args.get("config").cloned();
+        assert!(config.is_some());
+        assert_eq!(config.as_ref().unwrap()["port"], 8080);
+
+        let tags: Option<Vec<String>> = args.get("tags").and_then(|v| v.as_array()).map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        });
+        assert_eq!(
+            tags,
+            Some(vec![
+                "auth".to_string(),
+                "core".to_string(),
+                "security".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn test_update_component_args_partial() {
+        let args = json!({
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "name": "New Name"
+        });
+
+        let config = args.get("config").cloned();
+        assert!(config.is_none());
+
+        let tags: Option<Vec<String>> = args.get("tags").and_then(|v| v.as_array()).map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        });
+        assert!(tags.is_none());
+
+        let runtime = args
+            .get("runtime")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        assert!(runtime.is_none());
+    }
+
+    #[test]
+    fn test_delete_handlers_uuid_parsing() {
+        // All delete handlers just need a valid UUID
+        let args = json!({"task_id": "550e8400-e29b-41d4-a716-446655440000"});
+        assert!(parse_uuid(&args, "task_id").is_ok());
+
+        let args = json!({"step_id": "550e8400-e29b-41d4-a716-446655440000"});
+        assert!(parse_uuid(&args, "step_id").is_ok());
+
+        let args = json!({"release_id": "550e8400-e29b-41d4-a716-446655440000"});
+        assert!(parse_uuid(&args, "release_id").is_ok());
+
+        let args = json!({"milestone_id": "550e8400-e29b-41d4-a716-446655440000"});
+        assert!(parse_uuid(&args, "milestone_id").is_ok());
+
+        let args = json!({"decision_id": "550e8400-e29b-41d4-a716-446655440000"});
+        assert!(parse_uuid(&args, "decision_id").is_ok());
+
+        let args = json!({"constraint_id": "550e8400-e29b-41d4-a716-446655440000"});
+        assert!(parse_uuid(&args, "constraint_id").is_ok());
+    }
+
+    #[test]
+    fn test_delete_handlers_missing_uuid() {
+        assert!(parse_uuid(&json!({}), "task_id").is_err());
+        assert!(parse_uuid(&json!({}), "step_id").is_err());
+        assert!(parse_uuid(&json!({}), "release_id").is_err());
+        assert!(parse_uuid(&json!({}), "milestone_id").is_err());
+        assert!(parse_uuid(&json!({}), "decision_id").is_err());
+        assert!(parse_uuid(&json!({}), "constraint_id").is_err());
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -94,6 +94,20 @@ fn project_tools() -> Vec<ToolDefinition> {
             },
         },
         ToolDefinition {
+            name: "update_project".to_string(),
+            description: "Update a project's name, description, or root_path".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "slug": {"type": "string", "description": "Project slug"},
+                    "name": {"type": "string", "description": "New project name"},
+                    "description": {"type": "string", "description": "New description"},
+                    "root_path": {"type": "string", "description": "New root path"}
+                })),
+                required: Some(vec!["slug".to_string()]),
+            },
+        },
+        ToolDefinition {
             name: "get_project_roadmap".to_string(),
             description: "Get aggregated roadmap view with milestones, releases, and progress"
                 .to_string(),
@@ -315,6 +329,17 @@ fn task_tools() -> Vec<ToolDefinition> {
             },
         },
         ToolDefinition {
+            name: "delete_task".to_string(),
+            description: "Delete a task and all its steps and decisions".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "task_id": {"type": "string", "description": "Task UUID"}
+                })),
+                required: Some(vec!["task_id".to_string()]),
+            },
+        },
+        ToolDefinition {
             name: "get_next_task".to_string(),
             description: "Get the next available task from a plan (unblocked, highest priority)"
                 .to_string(),
@@ -462,6 +487,28 @@ fn step_tools() -> Vec<ToolDefinition> {
             },
         },
         ToolDefinition {
+            name: "get_step".to_string(),
+            description: "Get a step by ID".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "step_id": {"type": "string", "description": "Step UUID"}
+                })),
+                required: Some(vec!["step_id".to_string()]),
+            },
+        },
+        ToolDefinition {
+            name: "delete_step".to_string(),
+            description: "Delete a step".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "step_id": {"type": "string", "description": "Step UUID"}
+                })),
+                required: Some(vec!["step_id".to_string()]),
+            },
+        },
+        ToolDefinition {
             name: "get_step_progress".to_string(),
             description: "Get step completion progress for a task".to_string(),
             input_schema: InputSchema {
@@ -508,6 +555,31 @@ fn constraint_tools() -> Vec<ToolDefinition> {
                     "constraint_type".to_string(),
                     "description".to_string(),
                 ]),
+            },
+        },
+        ToolDefinition {
+            name: "get_constraint".to_string(),
+            description: "Get a constraint by ID".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "constraint_id": {"type": "string", "description": "Constraint UUID"}
+                })),
+                required: Some(vec!["constraint_id".to_string()]),
+            },
+        },
+        ToolDefinition {
+            name: "update_constraint".to_string(),
+            description: "Update a constraint's description, type, or enforced_by".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "constraint_id": {"type": "string", "description": "Constraint UUID"},
+                    "description": {"type": "string", "description": "New description"},
+                    "constraint_type": {"type": "string", "description": "New type (performance, security, style, compatibility, other)"},
+                    "enforced_by": {"type": "string", "description": "New enforced_by"}
+                })),
+                required: Some(vec!["constraint_id".to_string()]),
             },
         },
         ToolDefinition {
@@ -582,6 +654,17 @@ fn release_tools() -> Vec<ToolDefinition> {
                     "released_at": {"type": "string", "description": "Actual release date"},
                     "title": {"type": "string", "description": "New title"},
                     "description": {"type": "string", "description": "New description"}
+                })),
+                required: Some(vec!["release_id".to_string()]),
+            },
+        },
+        ToolDefinition {
+            name: "delete_release".to_string(),
+            description: "Delete a release".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "release_id": {"type": "string", "description": "Release UUID"}
                 })),
                 required: Some(vec!["release_id".to_string()]),
             },
@@ -670,6 +753,17 @@ fn milestone_tools() -> Vec<ToolDefinition> {
                     "closed_at": {"type": "string", "description": "Closure date"},
                     "title": {"type": "string", "description": "New title"},
                     "description": {"type": "string", "description": "New description"}
+                })),
+                required: Some(vec!["milestone_id".to_string()]),
+            },
+        },
+        ToolDefinition {
+            name: "delete_milestone".to_string(),
+            description: "Delete a milestone".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "milestone_id": {"type": "string", "description": "Milestone UUID"}
                 })),
                 required: Some(vec!["milestone_id".to_string()]),
             },
@@ -924,18 +1018,56 @@ fn code_tools() -> Vec<ToolDefinition> {
 // ============================================================================
 
 fn decision_tools() -> Vec<ToolDefinition> {
-    vec![ToolDefinition {
-        name: "search_decisions".to_string(),
-        description: "Search architectural decisions".to_string(),
-        input_schema: InputSchema {
-            schema_type: "object".to_string(),
-            properties: Some(json!({
-                "query": {"type": "string", "description": "Search query"},
-                "limit": {"type": "integer", "description": "Max results"}
-            })),
-            required: Some(vec!["query".to_string()]),
+    vec![
+        ToolDefinition {
+            name: "get_decision".to_string(),
+            description: "Get a decision by ID".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "decision_id": {"type": "string", "description": "Decision UUID"}
+                })),
+                required: Some(vec!["decision_id".to_string()]),
+            },
         },
-    }]
+        ToolDefinition {
+            name: "update_decision".to_string(),
+            description: "Update a decision's description, rationale, or chosen_option".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "decision_id": {"type": "string", "description": "Decision UUID"},
+                    "description": {"type": "string", "description": "New description"},
+                    "rationale": {"type": "string", "description": "New rationale"},
+                    "chosen_option": {"type": "string", "description": "New chosen option"}
+                })),
+                required: Some(vec!["decision_id".to_string()]),
+            },
+        },
+        ToolDefinition {
+            name: "delete_decision".to_string(),
+            description: "Delete a decision".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "decision_id": {"type": "string", "description": "Decision UUID"}
+                })),
+                required: Some(vec!["decision_id".to_string()]),
+            },
+        },
+        ToolDefinition {
+            name: "search_decisions".to_string(),
+            description: "Search architectural decisions".to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "query": {"type": "string", "description": "Search query"},
+                    "limit": {"type": "integer", "description": "Max results"}
+                })),
+                required: Some(vec!["query".to_string()]),
+            },
+        },
+    ]
 }
 
 // ============================================================================
@@ -1248,7 +1380,8 @@ fn note_tools() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "get_propagated_notes".to_string(),
-            description: "Get notes propagated through the graph (not directly attached)".to_string(),
+            description: "Get notes propagated through the graph (not directly attached)"
+                .to_string(),
             input_schema: InputSchema {
                 schema_type: "object".to_string(),
                 properties: Some(json!({
@@ -1541,6 +1674,23 @@ fn workspace_tools() -> Vec<ToolDefinition> {
             },
         },
         ToolDefinition {
+            name: "update_resource".to_string(),
+            description: "Update a resource's name, file_path, url, version, or description"
+                .to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "id": {"type": "string", "description": "Resource UUID"},
+                    "name": {"type": "string", "description": "New name"},
+                    "file_path": {"type": "string", "description": "New file path"},
+                    "url": {"type": "string", "description": "New URL"},
+                    "version": {"type": "string", "description": "New version"},
+                    "description": {"type": "string", "description": "New description"}
+                })),
+                required: Some(vec!["id".to_string()]),
+            },
+        },
+        ToolDefinition {
             name: "delete_resource".to_string(),
             description: "Delete a resource".to_string(),
             input_schema: InputSchema {
@@ -1616,6 +1766,23 @@ fn workspace_tools() -> Vec<ToolDefinition> {
             },
         },
         ToolDefinition {
+            name: "update_component".to_string(),
+            description: "Update a component's name, description, runtime, config, or tags"
+                .to_string(),
+            input_schema: InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(json!({
+                    "id": {"type": "string", "description": "Component UUID"},
+                    "name": {"type": "string", "description": "New name"},
+                    "description": {"type": "string", "description": "New description"},
+                    "runtime": {"type": "string", "description": "New runtime"},
+                    "config": {"type": "object", "description": "New configuration"},
+                    "tags": {"type": "array", "items": {"type": "string"}, "description": "New tags"}
+                })),
+                required: Some(vec!["id".to_string()]),
+            },
+        },
+        ToolDefinition {
             name: "delete_component".to_string(),
             description: "Delete a component".to_string(),
             input_schema: InputSchema {
@@ -1686,7 +1853,7 @@ mod tests {
     #[test]
     fn test_all_tools_count() {
         let tools = all_tools();
-        assert_eq!(tools.len(), 117, "Expected 117 tools, got {}", tools.len());
+        assert_eq!(tools.len(), 130, "Expected 130 tools, got {}", tools.len());
     }
 
     #[test]
@@ -1714,8 +1881,8 @@ mod tests {
         let tools = workspace_tools();
         assert_eq!(
             tools.len(),
-            29,
-            "Expected 29 workspace tools, got {}",
+            31,
+            "Expected 31 workspace tools, got {}",
             tools.len()
         );
     }
@@ -1815,5 +1982,169 @@ mod tests {
                 tool.name
             );
         }
+    }
+
+    #[test]
+    fn test_new_crud_tools_exist() {
+        let tools = all_tools();
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+
+        // All 13 new tools from the CRUD completion plan
+        let new_tools = [
+            "update_project",
+            "delete_task",
+            "get_step",
+            "delete_step",
+            "get_constraint",
+            "update_constraint",
+            "delete_release",
+            "delete_milestone",
+            "get_decision",
+            "update_decision",
+            "delete_decision",
+            "update_resource",
+            "update_component",
+        ];
+
+        for tool_name in &new_tools {
+            assert!(
+                names.contains(tool_name),
+                "Missing new CRUD tool: {}",
+                tool_name
+            );
+        }
+    }
+
+    #[test]
+    fn test_new_crud_tools_required_params() {
+        let tools = all_tools();
+
+        // update_project requires slug
+        let t = tools.iter().find(|t| t.name == "update_project").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"slug".to_string()));
+
+        // delete_task requires task_id
+        let t = tools.iter().find(|t| t.name == "delete_task").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"task_id".to_string()));
+
+        // get_step requires step_id
+        let t = tools.iter().find(|t| t.name == "get_step").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"step_id".to_string()));
+
+        // delete_step requires step_id
+        let t = tools.iter().find(|t| t.name == "delete_step").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"step_id".to_string()));
+
+        // get_constraint requires constraint_id
+        let t = tools.iter().find(|t| t.name == "get_constraint").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"constraint_id".to_string()));
+
+        // update_constraint requires constraint_id
+        let t = tools
+            .iter()
+            .find(|t| t.name == "update_constraint")
+            .unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"constraint_id".to_string()));
+
+        // delete_release requires release_id
+        let t = tools.iter().find(|t| t.name == "delete_release").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"release_id".to_string()));
+
+        // delete_milestone requires milestone_id
+        let t = tools.iter().find(|t| t.name == "delete_milestone").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"milestone_id".to_string()));
+
+        // get_decision requires decision_id
+        let t = tools.iter().find(|t| t.name == "get_decision").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"decision_id".to_string()));
+
+        // update_decision requires decision_id
+        let t = tools.iter().find(|t| t.name == "update_decision").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"decision_id".to_string()));
+
+        // delete_decision requires decision_id
+        let t = tools.iter().find(|t| t.name == "delete_decision").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"decision_id".to_string()));
+
+        // update_resource requires id
+        let t = tools.iter().find(|t| t.name == "update_resource").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"id".to_string()));
+
+        // update_component requires id
+        let t = tools.iter().find(|t| t.name == "update_component").unwrap();
+        let req = t.input_schema.required.as_ref().unwrap();
+        assert!(req.contains(&"id".to_string()));
+    }
+
+    #[test]
+    fn test_new_crud_tools_have_properties() {
+        let tools = all_tools();
+
+        // update_project should have slug, name, description, root_path
+        let t = tools.iter().find(|t| t.name == "update_project").unwrap();
+        let props = t.input_schema.properties.as_ref().unwrap();
+        assert!(props.get("slug").is_some());
+        assert!(props.get("name").is_some());
+        assert!(props.get("description").is_some());
+        assert!(props.get("root_path").is_some());
+
+        // update_constraint should have constraint_id, description, constraint_type, enforced_by
+        let t = tools
+            .iter()
+            .find(|t| t.name == "update_constraint")
+            .unwrap();
+        let props = t.input_schema.properties.as_ref().unwrap();
+        assert!(props.get("constraint_id").is_some());
+        assert!(props.get("description").is_some());
+        assert!(props.get("constraint_type").is_some());
+        assert!(props.get("enforced_by").is_some());
+
+        // update_decision should have decision_id, description, rationale, chosen_option
+        let t = tools.iter().find(|t| t.name == "update_decision").unwrap();
+        let props = t.input_schema.properties.as_ref().unwrap();
+        assert!(props.get("decision_id").is_some());
+        assert!(props.get("description").is_some());
+        assert!(props.get("rationale").is_some());
+        assert!(props.get("chosen_option").is_some());
+
+        // update_resource should have id, name, file_path, url, version, description
+        let t = tools.iter().find(|t| t.name == "update_resource").unwrap();
+        let props = t.input_schema.properties.as_ref().unwrap();
+        assert!(props.get("id").is_some());
+        assert!(props.get("name").is_some());
+        assert!(props.get("file_path").is_some());
+        assert!(props.get("url").is_some());
+        assert!(props.get("version").is_some());
+        assert!(props.get("description").is_some());
+
+        // update_component should have id, name, description, runtime, config, tags
+        let t = tools.iter().find(|t| t.name == "update_component").unwrap();
+        let props = t.input_schema.properties.as_ref().unwrap();
+        assert!(props.get("id").is_some());
+        assert!(props.get("name").is_some());
+        assert!(props.get("description").is_some());
+        assert!(props.get("runtime").is_some());
+        assert!(props.get("config").is_some());
+        assert!(props.get("tags").is_some());
+    }
+
+    #[test]
+    fn test_workspace_tools_include_update_resource_and_component() {
+        let tools = workspace_tools();
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"update_resource"));
+        assert!(names.contains(&"update_component"));
     }
 }

--- a/src/plan/manager.rs
+++ b/src/plan/manager.rs
@@ -311,6 +311,11 @@ impl PlanManager {
         Ok(())
     }
 
+    /// Delete a task and all its related data (steps, decisions)
+    pub async fn delete_task(&self, task_id: Uuid) -> Result<()> {
+        self.neo4j.delete_task(task_id).await
+    }
+
     /// Get next available task from a plan
     pub async fn get_next_available_task(&self, plan_id: Uuid) -> Result<Option<TaskNode>> {
         self.neo4j.get_next_available_task(plan_id).await


### PR DESCRIPTION
Add the 3 MCP tools that were missing for complete parity with REST API:
- list_project_notes: List notes for a specific project
- get_propagated_notes: Get notes propagated through the graph
- get_entity_notes: Get notes directly attached to an entity

Total MCP tools: 114 → 117