### PR TITLE
feat(events): bridge MCP mutations to HTTP WebSocket via EventNotifier

### DIFF
--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -430,6 +430,8 @@ pub fn create_router(state: OrchestratorState) -> Router {
         // WebSocket CRUD Event Notifications
         // ====================================================================
         .route("/ws/events", get(ws_handlers::ws_events))
+        // Internal: receive CrudEvent from MCP server
+        .route("/internal/events", post(handlers::receive_event))
         // ====================================================================
         // Chat (SSE streaming + session management)
         // ====================================================================

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -5,7 +5,9 @@
 //! - `EventBus` — broadcast channel for distributing events to WebSocket clients
 
 mod bus;
+mod notifier;
 mod types;
 
 pub use bus::EventBus;
-pub use types::{CrudAction, CrudEvent, EntityType, RelatedEntity};
+pub use notifier::EventNotifier;
+pub use types::{CrudAction, CrudEvent, EntityType, EventEmitter, RelatedEntity};

--- a/src/events/notifier.rs
+++ b/src/events/notifier.rs
@@ -1,0 +1,137 @@
+//! HTTP-based event notifier for bridging MCP → HTTP server
+//!
+//! Sends CrudEvents to the HTTP server via POST /internal/events.
+//! Fire-and-forget: errors are logged but never block the caller.
+
+use super::types::{CrudEvent, EventEmitter};
+use std::time::Duration;
+use tracing::warn;
+
+/// HTTP client that forwards CrudEvents to the HTTP server's /internal/events endpoint.
+///
+/// Used by the MCP server to notify the HTTP server (which owns the WebSocket connections)
+/// of mutations so the frontend receives real-time updates.
+#[derive(Clone)]
+pub struct EventNotifier {
+    client: reqwest::Client,
+    url: String,
+}
+
+impl EventNotifier {
+    /// Create a new EventNotifier targeting the given base URL
+    ///
+    /// The base_url should be the HTTP server root (e.g. "http://localhost:8080").
+    pub fn new(base_url: &str) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("Failed to create reqwest client");
+
+        let url = format!("{}/internal/events", base_url.trim_end_matches('/'));
+
+        Self { client, url }
+    }
+}
+
+impl EventEmitter for EventNotifier {
+    fn emit(&self, event: CrudEvent) {
+        let client = self.client.clone();
+        let url = self.url.clone();
+
+        tokio::spawn(async move {
+            if let Err(e) = client.post(&url).json(&event).send().await {
+                warn!(
+                    url = %url,
+                    entity_type = ?event.entity_type,
+                    action = ?event.action,
+                    "Failed to forward event to HTTP server: {}",
+                    e
+                );
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::EntityType;
+
+    #[test]
+    fn test_new_builds_correct_url() {
+        let notifier = EventNotifier::new("http://localhost:8080");
+        assert_eq!(notifier.url, "http://localhost:8080/internal/events");
+    }
+
+    #[test]
+    fn test_new_trims_trailing_slash() {
+        let notifier = EventNotifier::new("http://localhost:8080/");
+        assert_eq!(notifier.url, "http://localhost:8080/internal/events");
+    }
+
+    #[test]
+    fn test_clone() {
+        let notifier = EventNotifier::new("http://localhost:8080");
+        let cloned = notifier.clone();
+        assert_eq!(cloned.url, notifier.url);
+    }
+
+    #[tokio::test]
+    async fn test_emit_fire_and_forget_no_panic() {
+        // Even with no server listening, emit should not panic
+        let notifier = EventNotifier::new("http://127.0.0.1:1"); // Port 1 — nothing listening
+        notifier.emit_created(
+            EntityType::Plan,
+            "plan-1",
+            serde_json::json!({"title": "Test"}),
+            None,
+        );
+        // Give the spawned task a moment to execute (and fail gracefully)
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    #[tokio::test]
+    async fn test_emit_deleted_no_panic() {
+        let notifier = EventNotifier::new("http://127.0.0.1:1");
+        notifier.emit_deleted(EntityType::Task, "task-1", Some("proj-1".into()));
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    #[tokio::test]
+    async fn test_emit_linked_no_panic() {
+        let notifier = EventNotifier::new("http://127.0.0.1:1");
+        notifier.emit_linked(
+            EntityType::Task,
+            "task-1",
+            EntityType::Release,
+            "release-1",
+            None,
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    #[tokio::test]
+    async fn test_emit_unlinked_no_panic() {
+        let notifier = EventNotifier::new("http://127.0.0.1:1");
+        notifier.emit_unlinked(
+            EntityType::Note,
+            "note-1",
+            EntityType::Task,
+            "task-2",
+            Some("proj-1".into()),
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    #[tokio::test]
+    async fn test_emit_updated_no_panic() {
+        let notifier = EventNotifier::new("http://127.0.0.1:1");
+        notifier.emit_updated(
+            EntityType::Plan,
+            "plan-1",
+            serde_json::json!({"status": "completed"}),
+            None,
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}

--- a/src/notes/manager.rs
+++ b/src/notes/manager.rs
@@ -4,7 +4,7 @@
 //! including linking notes to entities and managing note lifecycle.
 
 use super::models::*;
-use crate::events::{CrudAction, CrudEvent, EntityType as EventEntityType, EventBus};
+use crate::events::{CrudAction, CrudEvent, EntityType as EventEntityType, EventEmitter};
 use crate::meilisearch::indexes::NoteDocument;
 use crate::meilisearch::SearchStore;
 use crate::neo4j::GraphStore;
@@ -16,7 +16,7 @@ use uuid::Uuid;
 pub struct NoteManager {
     neo4j: Arc<dyn GraphStore>,
     meilisearch: Arc<dyn SearchStore>,
-    event_bus: Option<Arc<EventBus>>,
+    event_emitter: Option<Arc<dyn EventEmitter>>,
 }
 
 impl NoteManager {
@@ -25,27 +25,27 @@ impl NoteManager {
         Self {
             neo4j,
             meilisearch,
-            event_bus: None,
+            event_emitter: None,
         }
     }
 
-    /// Create a new NoteManager with an event bus
-    pub fn with_event_bus(
+    /// Create a new NoteManager with an event emitter
+    pub fn with_event_emitter(
         neo4j: Arc<dyn GraphStore>,
         meilisearch: Arc<dyn SearchStore>,
-        event_bus: Arc<EventBus>,
+        emitter: Arc<dyn EventEmitter>,
     ) -> Self {
         Self {
             neo4j,
             meilisearch,
-            event_bus: Some(event_bus),
+            event_emitter: Some(emitter),
         }
     }
 
-    /// Emit a CRUD event (no-op if event_bus is None)
+    /// Emit a CRUD event (no-op if event_emitter is None)
     fn emit(&self, event: crate::events::CrudEvent) {
-        if let Some(bus) = &self.event_bus {
-            bus.emit(event);
+        if let Some(emitter) = &self.event_emitter {
+            emitter.emit(event);
         }
     }
 

--- a/src/plan/manager.rs
+++ b/src/plan/manager.rs
@@ -1,7 +1,7 @@
 //! Plan management operations
 
 use super::models::*;
-use crate::events::{CrudAction, CrudEvent, EntityType, EventBus};
+use crate::events::{CrudAction, CrudEvent, EntityType, EventEmitter};
 use crate::meilisearch::indexes::DecisionDocument;
 use crate::meilisearch::SearchStore;
 use crate::neo4j::models::*;
@@ -14,7 +14,7 @@ use uuid::Uuid;
 pub struct PlanManager {
     neo4j: Arc<dyn GraphStore>,
     meili: Arc<dyn SearchStore>,
-    event_bus: Option<Arc<EventBus>>,
+    event_emitter: Option<Arc<dyn EventEmitter>>,
 }
 
 impl PlanManager {
@@ -23,27 +23,27 @@ impl PlanManager {
         Self {
             neo4j,
             meili,
-            event_bus: None,
+            event_emitter: None,
         }
     }
 
-    /// Create a new plan manager with an event bus
-    pub fn with_event_bus(
+    /// Create a new plan manager with an event emitter
+    pub fn with_event_emitter(
         neo4j: Arc<dyn GraphStore>,
         meili: Arc<dyn SearchStore>,
-        event_bus: Arc<EventBus>,
+        emitter: Arc<dyn EventEmitter>,
     ) -> Self {
         Self {
             neo4j,
             meili,
-            event_bus: Some(event_bus),
+            event_emitter: Some(emitter),
         }
     }
 
-    /// Emit a CRUD event (no-op if event_bus is None)
+    /// Emit a CRUD event (no-op if event_emitter is None)
     fn emit(&self, event: CrudEvent) {
-        if let Some(bus) = &self.event_bus {
-            bus.emit(event);
+        if let Some(emitter) = &self.event_emitter {
+            emitter.emit(event);
         }
     }
 


### PR DESCRIPTION
Extract EventEmitter trait from EventBus for polymorphic event dispatch. EventNotifier (fire-and-forget HTTP POST) forwards CrudEvents from MCP server to HTTP server's /internal/events endpoint, which re-broadcasts them over the existing WebSocket EventBus.

Architecture: Claude Code ←stdio→ MCP ──POST──→ HTTP ──ws──→ Frontend

- Add EventEmitter trait (dyn-compatible, 5 default convenience methods)
- Add EventNotifier: reqwest-based fire-and-forget HTTP client
- Add POST /internal/events endpoint for receiving bridged events
- Refactor PlanManager/NoteManager: Arc<EventBus> → Arc<dyn EventEmitter>
- Add Orchestrator::with_event_emitter() for MCP server use
- Wire MCP_HTTP_URL env var in mcp_server binary
- Add 18 new tests (531 total, all passing)