### PR TITLE
feat(chat): out-of-band SDK event listener (plan 9a1684b2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,14 @@ jobs:
             --ignore RUSTSEC-2023-0071 \
             --ignore RUSTSEC-2026-0049 \
             --ignore RUSTSEC-2026-0098 \
-            --ignore RUSTSEC-2026-0099
+            --ignore RUSTSEC-2026-0099 \
+            --ignore RUSTSEC-2026-0104
         # Ignored advisories (transitive, no fix available):
         #   RUSTSEC-2023-0071: rsa — via jsonwebtoken 10.3.0 (upstream must bump)
         #   RUSTSEC-2026-0049: rustls-webpki 0.101.7 URI name constraints — via nexus-claude pinned reqwest 0.11
         #   RUSTSEC-2026-0098: rustls-webpki 0.101.7 wildcard name constraints — same transitive dep
         #   RUSTSEC-2026-0099: rustls-webpki 0.101.7 — same transitive dep
+        #   RUSTSEC-2026-0104: rustls-webpki 0.101.7 reachable panic in CRL parsing — same transitive dep
 
       - name: Run cargo deny (license + advisory check)
         run: cargo deny check advisories licenses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,7 +4780,6 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 [[package]]
 name = "nexus-claude"
 version = "0.5.0"
-source = "git+https://github.com/this-rs/nexus.git?rev=c9e0da3#c9e0da3a5cf5b5ef18b9bd974db6b12cc24825fd"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,6 +4780,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 [[package]]
 name = "nexus-claude"
 version = "0.5.0"
+source = "git+https://github.com/this-rs/nexus.git?rev=fc00740#fc00740a92659146bd3dbf869395ec7240e39c3c"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,3 +261,12 @@ post_install_script = "packaging/rpm/postinst.sh"
 
 [package.metadata.generate-rpm.requires]
 systemd = "*"
+
+# =============================================================================
+# Local development: override nexus-claude with the local clone while we
+# iterate on the OOB listener feature (T3 of plan 9a1684b2). Once the SDK
+# changes are pushed and tagged, replace this block with a `rev = "..."` bump
+# in [dependencies].
+# =============================================================================
+[patch."https://github.com/this-rs/nexus.git"]
+nexus-claude = { path = "/Users/triviere/projects/project-orchestrator/nexus/claude-code-sdk-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ async-trait = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # Chat / Claude Code SDK
-nexus-claude = { git = "https://github.com/this-rs/nexus.git", rev = "c9e0da3", features = ["memory", "auto-download"] }
+nexus-claude = { git = "https://github.com/this-rs/nexus.git", rev = "fc00740", features = ["memory", "auto-download"] }
 tokio-stream = { workspace = true }
 
 # Auth
@@ -262,11 +262,3 @@ post_install_script = "packaging/rpm/postinst.sh"
 [package.metadata.generate-rpm.requires]
 systemd = "*"
 
-# =============================================================================
-# Local development: override nexus-claude with the local clone while we
-# iterate on the OOB listener feature (T3 of plan 9a1684b2). Once the SDK
-# changes are pushed and tagged, replace this block with a `rev = "..."` bump
-# in [dependencies].
-# =============================================================================
-[patch."https://github.com/this-rs/nexus.git"]
-nexus-claude = { path = "/Users/triviere/projects/project-orchestrator/nexus/claude-code-sdk-rs" }

--- a/src/chat/drain.rs
+++ b/src/chat/drain.rs
@@ -59,79 +59,94 @@ pub(crate) async fn drain_pending_messages(
     };
 
     if let Some(next_msg) = next_message {
-        let is_system_hint = next_msg.kind == PendingMessageKind::SystemHint;
+        let kind = next_msg.kind.clone();
         let msg_content = next_msg.content;
 
         info!(
             "Processing queued {} for session {} (queue was non-empty after stream)",
-            if is_system_hint {
-                "system_hint"
-            } else {
-                "user_message"
+            match kind {
+                PendingMessageKind::SystemHint => "system_hint",
+                PendingMessageKind::User => "user_message",
+                PendingMessageKind::BackgroundOutput => "background_output",
             },
             session_id
         );
 
-        // Persist the event and update message count (only for user messages)
-        if let Some(uuid) = session_uuid {
-            if !is_system_hint {
-                if let Ok(Some(node)) = graph.get_chat_session(uuid).await {
-                    let _ = graph
-                        .update_chat_session(
-                            uuid,
-                            None,
-                            None,
-                            Some(node.message_count + 1),
-                            None,
-                            None,
-                            None,
-                        )
-                        .await;
+        // Persist the event and update message count.
+        // - SystemHint: persist as system_hint, no message_count bump
+        // - User: persist as user_message, bump message_count
+        // - BackgroundOutput: SKIP persist + SKIP broadcast — the OOB
+        //   listener has already done both before pushing to the queue
+        //   (see chat::oob_listener). Re-persisting would duplicate.
+        let needs_persist_and_broadcast = !matches!(kind, PendingMessageKind::BackgroundOutput);
+        if needs_persist_and_broadcast {
+            if let Some(uuid) = session_uuid {
+                if matches!(kind, PendingMessageKind::User) {
+                    if let Ok(Some(node)) = graph.get_chat_session(uuid).await {
+                        let _ = graph
+                            .update_chat_session(
+                                uuid,
+                                None,
+                                None,
+                                Some(node.message_count + 1),
+                                None,
+                                None,
+                                None,
+                            )
+                            .await;
+                    }
                 }
+
+                let (event_type, event_data) = match kind {
+                    PendingMessageKind::SystemHint => (
+                        "system_hint".to_string(),
+                        serde_json::to_string(&ChatEvent::SystemHint {
+                            content: msg_content.clone(),
+                        })
+                        .unwrap_or_default(),
+                    ),
+                    PendingMessageKind::User => (
+                        "user_message".to_string(),
+                        serde_json::to_string(&ChatEvent::UserMessage {
+                            content: msg_content.clone(),
+                        })
+                        .unwrap_or_default(),
+                    ),
+                    PendingMessageKind::BackgroundOutput => unreachable!(
+                        "BackgroundOutput is filtered out by needs_persist_and_broadcast"
+                    ),
+                };
+
+                let event_record = ChatEventRecord {
+                    id: Uuid::new_v4(),
+                    session_id: uuid,
+                    seq: next_seq.fetch_add(1, Ordering::SeqCst),
+                    event_type,
+                    data: event_data,
+                    created_at: chrono::Utc::now(),
+                };
+                let _ = graph.store_chat_events(uuid, vec![event_record]).await;
             }
 
-            let (event_type, event_data) = if is_system_hint {
-                (
-                    "system_hint".to_string(),
-                    serde_json::to_string(&ChatEvent::SystemHint {
-                        content: msg_content.clone(),
-                    })
-                    .unwrap_or_default(),
-                )
-            } else {
-                (
-                    "user_message".to_string(),
-                    serde_json::to_string(&ChatEvent::UserMessage {
-                        content: msg_content.clone(),
-                    })
-                    .unwrap_or_default(),
-                )
+            let chat_event = match kind {
+                PendingMessageKind::SystemHint => ChatEvent::SystemHint {
+                    content: msg_content.clone(),
+                },
+                PendingMessageKind::User => ChatEvent::UserMessage {
+                    content: msg_content.clone(),
+                },
+                PendingMessageKind::BackgroundOutput => unreachable!(),
             };
-
-            let event_record = ChatEventRecord {
-                id: Uuid::new_v4(),
-                session_id: uuid,
-                seq: next_seq.fetch_add(1, Ordering::SeqCst),
-                event_type,
-                data: event_data,
-                created_at: chrono::Utc::now(),
-            };
-            let _ = graph.store_chat_events(uuid, vec![event_record]).await;
-        }
-
-        // Emit the appropriate event on broadcast + NATS
-        let chat_event = if is_system_hint {
-            ChatEvent::SystemHint {
-                content: msg_content.clone(),
+            let _ = events_tx.send(chat_event.clone());
+            if let Some(ref nats) = nats {
+                nats.publish_chat_event(&session_id, chat_event);
             }
         } else {
-            ChatEvent::UserMessage {
-                content: msg_content.clone(),
-            }
-        };
-        let _ = events_tx.send(chat_event.clone());
-        if let Some(ref nats) = nats {
-            nats.publish_chat_event(&session_id, chat_event);
+            debug!(
+                session_id = %session_id,
+                "Drain: BackgroundOutput already persisted/broadcasted by OOB listener — \
+                 forwarding content to stream_response as prompt"
+            );
         }
 
         // Recursive call to process the queued message

--- a/src/chat/manager.rs
+++ b/src/chat/manager.rs
@@ -31,7 +31,7 @@ use nexus_claude::{
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -41,6 +41,18 @@ use crate::expand_tilde;
 
 /// Broadcast channel buffer size for WebSocket subscribers
 const BROADCAST_BUFFER: usize = 256;
+
+/// OOB-triggered `stream_response` rate cap for interactive sessions.
+/// A misbehaving Monitor or background Bash that emits constantly could
+/// otherwise loop the session and inflate the LLM bill — this caps the
+/// number of OOB-driven LLM turns to 50 over a rolling 5-min window
+/// (T7 of plan 9a1684b2).
+pub(crate) const OOB_TRIGGER_CAP_INTERACTIVE: u32 = 50;
+/// Same cap for runner sessions, more conservative since they run
+/// autonomously without a human watching.
+pub(crate) const OOB_TRIGGER_CAP_RUNNER: u32 = 5;
+/// Rolling window for the OOB trigger cap.
+pub(crate) const OOB_TRIGGER_WINDOW_SECS: u64 = 300;
 
 /// An active chat session with a live Claude CLI subprocess
 pub struct ActiveSession {
@@ -142,6 +154,21 @@ pub struct ActiveSession {
     /// steps completed, last tool used. Source of truth for resumption after
     /// compaction or max_turns.
     pub work_log: Arc<Mutex<SessionWorkLog>>,
+    /// Sliding-window history of OOB-triggered `stream_response` spawn
+    /// timestamps (T7 of plan 9a1684b2). Used by `chat::oob_listener` to
+    /// enforce a rate cap that prevents a runaway Monitor / background
+    /// Bash from looping the session indefinitely.
+    pub oob_trigger_history: Arc<Mutex<VecDeque<Instant>>>,
+    /// Maximum OOB-triggered turns within `oob_trigger_window`. Set to
+    /// `OOB_TRIGGER_CAP_INTERACTIVE` (50) for interactive sessions and
+    /// `OOB_TRIGGER_CAP_RUNNER` (5) for runner sessions.
+    pub oob_trigger_cap: u32,
+    /// Rolling window for the OOB trigger cap. Defaults to 5 minutes.
+    pub oob_trigger_window: Duration,
+    /// Anti-spam flag: set to true the first time the cap is hit in a
+    /// window so we emit the SystemHint warning only once per window.
+    /// Reset to false the next time we observe `len < cap` after draining.
+    pub oob_capped_warned: Arc<AtomicBool>,
 }
 
 /// Runtime-mutable environment config for Claude CLI subprocess.
@@ -2588,6 +2615,13 @@ impl ChatManager {
         // Runner sessions: limit to 5 auto-continues to prevent infinite loops.
         // Interactive sessions: unlimited (0) — user can always interrupt manually.
         let max_auto_continues: u32 = if is_runner_session { 5 } else { 0 };
+        // OOB-trigger cap (T7 of plan 9a1684b2): conservative for runner
+        // sessions, generous for interactive (user can always interrupt).
+        let oob_trigger_cap: u32 = if is_runner_session {
+            OOB_TRIGGER_CAP_RUNNER
+        } else {
+            OOB_TRIGGER_CAP_INTERACTIVE
+        };
         let interrupt_flag = {
             let mut sessions = self.active_sessions.write().await;
             // Cancel stale NATS listeners from a previous session with the same ID
@@ -2635,6 +2669,10 @@ impl ChatManager {
                     objective_tracking: true,
                     objective_reminder_turns_since: Arc::new(AtomicU32::new(0)),
                     work_log: work_log.clone(),
+                    oob_trigger_history: Arc::new(Mutex::new(VecDeque::new())),
+                    oob_trigger_cap,
+                    oob_trigger_window: Duration::from_secs(OOB_TRIGGER_WINDOW_SECS),
+                    oob_capped_warned: Arc::new(AtomicBool::new(false)),
                 },
             );
             interrupt_flag
@@ -4701,6 +4739,12 @@ impl ChatManager {
                     objective_tracking: true,
                     objective_reminder_turns_since: Arc::new(AtomicU32::new(0)),
                     work_log: work_log.clone(),
+                    // Resumed sessions = interactive: use the generous cap (50/5min).
+                    // T7 of plan 9a1684b2.
+                    oob_trigger_history: Arc::new(Mutex::new(VecDeque::new())),
+                    oob_trigger_cap: OOB_TRIGGER_CAP_INTERACTIVE,
+                    oob_trigger_window: Duration::from_secs(OOB_TRIGGER_WINDOW_SECS),
+                    oob_capped_warned: Arc::new(AtomicBool::new(false)),
                 },
             );
             interrupt_flag
@@ -7368,6 +7412,10 @@ mod tests {
             objective_tracking: false,
             objective_reminder_turns_since: Arc::new(AtomicU32::new(0)),
             work_log: Arc::new(Mutex::new(SessionWorkLog::default())),
+            oob_trigger_history: Arc::new(Mutex::new(VecDeque::new())),
+            oob_trigger_cap: OOB_TRIGGER_CAP_INTERACTIVE,
+            oob_trigger_window: Duration::from_secs(OOB_TRIGGER_WINDOW_SECS),
+            oob_capped_warned: Arc::new(AtomicBool::new(false)),
         };
 
         Some((session, pending_messages))
@@ -8264,6 +8312,10 @@ mod tests {
             objective_tracking: false,
             objective_reminder_turns_since: Arc::new(AtomicU32::new(0)),
             work_log: Arc::new(Mutex::new(SessionWorkLog::default())),
+            oob_trigger_history: Arc::new(Mutex::new(VecDeque::new())),
+            oob_trigger_cap: OOB_TRIGGER_CAP_INTERACTIVE,
+            oob_trigger_window: Duration::from_secs(OOB_TRIGGER_WINDOW_SECS),
+            oob_capped_warned: Arc::new(AtomicBool::new(false)),
         };
 
         (session, handle)

--- a/src/chat/manager.rs
+++ b/src/chat/manager.rs
@@ -2662,18 +2662,32 @@ impl ChatManager {
             nats_cancel.clone(),
         );
 
-        // Spawn the permanent out-of-band SDK message listener (T4 of plan
-        // 9a1684b2). Captures Messages emitted by the CLI subprocess
+        // Spawn the permanent out-of-band SDK message listener (T4+T5 of
+        // plan 9a1684b2). Captures Messages emitted by the CLI subprocess
         // between turns (background tool notifications, etc.) and
-        // surfaces them as ChatEvent::BackgroundOutput on the session
-        // broadcast. Stops cleanly on `nats_cancel` (shared with NATS
-        // listeners — one cancel for all session-bound background tasks).
+        // surfaces them as ChatEvent::BackgroundOutput. When a turn is
+        // not active and an OOB event arrives, the listener also pushes
+        // a PendingMessage::BackgroundOutput and tries to claim
+        // is_streaming via compare_exchange to spawn a fresh
+        // stream_response — letting the LLM react autonomously without
+        // waiting for the next user turn.
         super::oob_listener::spawn_oob_listener(
             session_id.to_string(),
             client.clone(),
             events_tx.clone(),
             is_streaming.clone(),
+            next_seq.clone(),
             nats_cancel,
+            super::oob_listener::OobListenerDeps {
+                graph: self.graph.clone(),
+                active_sessions: self.active_sessions.clone(),
+                context_injector: self.context_injector.clone(),
+                event_emitter: self.event_emitter.clone(),
+                retry_config: self.config.retry.clone(),
+                enrichment_pipeline: self.enrichment_pipeline.clone(),
+                search: self.search.clone(),
+                nats: self.nats.clone(),
+            },
         );
 
         // Persist the initial user_message event
@@ -4714,17 +4728,28 @@ impl ChatManager {
             nats_cancel.clone(),
         );
 
-        // Spawn the permanent out-of-band SDK message listener (T4 of plan
-        // 9a1684b2). Same as `create_session` — the resumed session needs
-        // its own listener bound to the new InteractiveClient. The old
-        // listener (if any) was already cancelled above via
+        // Spawn the permanent out-of-band SDK message listener (T4+T5 of
+        // plan 9a1684b2). Same as `create_session` — the resumed session
+        // needs its own listener bound to the new InteractiveClient. The
+        // old listener (if any) was already cancelled above via
         // `old_session.nats_cancel.cancel()`.
         super::oob_listener::spawn_oob_listener(
             session_id.to_string(),
             client.clone(),
             events_tx.clone(),
             is_streaming.clone(),
+            next_seq.clone(),
             nats_cancel,
+            super::oob_listener::OobListenerDeps {
+                graph: self.graph.clone(),
+                active_sessions: self.active_sessions.clone(),
+                context_injector: self.context_injector.clone(),
+                event_emitter: self.event_emitter.clone(),
+                retry_config: self.config.retry.clone(),
+                enrichment_pipeline: self.enrichment_pipeline.clone(),
+                search: self.search.clone(),
+                nats: self.nats.clone(),
+            },
         );
 
         // Persist the user_message event

--- a/src/chat/manager.rs
+++ b/src/chat/manager.rs
@@ -2659,6 +2659,20 @@ impl ChatManager {
         self.spawn_nats_rpc_listener(
             &session_id.to_string(),
             self.active_sessions.clone(),
+            nats_cancel.clone(),
+        );
+
+        // Spawn the permanent out-of-band SDK message listener (T4 of plan
+        // 9a1684b2). Captures Messages emitted by the CLI subprocess
+        // between turns (background tool notifications, etc.) and
+        // surfaces them as ChatEvent::BackgroundOutput on the session
+        // broadcast. Stops cleanly on `nats_cancel` (shared with NATS
+        // listeners — one cancel for all session-bound background tasks).
+        super::oob_listener::spawn_oob_listener(
+            session_id.to_string(),
+            client.clone(),
+            events_tx.clone(),
+            is_streaming.clone(),
             nats_cancel,
         );
 
@@ -4694,7 +4708,24 @@ impl ChatManager {
         );
 
         // Spawn NATS RPC send listener for cross-instance message routing
-        self.spawn_nats_rpc_listener(session_id, self.active_sessions.clone(), nats_cancel);
+        self.spawn_nats_rpc_listener(
+            session_id,
+            self.active_sessions.clone(),
+            nats_cancel.clone(),
+        );
+
+        // Spawn the permanent out-of-band SDK message listener (T4 of plan
+        // 9a1684b2). Same as `create_session` — the resumed session needs
+        // its own listener bound to the new InteractiveClient. The old
+        // listener (if any) was already cancelled above via
+        // `old_session.nats_cancel.cancel()`.
+        super::oob_listener::spawn_oob_listener(
+            session_id.to_string(),
+            client.clone(),
+            events_tx.clone(),
+            is_streaming.clone(),
+            nats_cancel,
+        );
 
         // Persist the user_message event
         let user_event = ChatEventRecord {

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -16,6 +16,7 @@ pub mod entity_extractor;
 pub mod feedback;
 pub mod manager;
 pub mod observation_detector;
+pub(crate) mod oob_listener;
 pub mod path_detect;
 pub(crate) mod post_stream;
 pub(crate) mod post_tool_hook;

--- a/src/chat/oob_listener.rs
+++ b/src/chat/oob_listener.rs
@@ -52,8 +52,8 @@
 //!      dropped.
 
 use std::collections::{HashMap, VecDeque};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
@@ -61,7 +61,7 @@ use futures::StreamExt;
 use nexus_claude::{
     AssistantMessage, ContentBlock, ContentValue, InteractiveClient, Message, UserMessage,
 };
-use tokio::sync::{Mutex, RwLock, broadcast};
+use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -69,8 +69,8 @@ use uuid::Uuid;
 use super::manager::{ActiveSession, ChatManager};
 use super::types::{ChatEvent, PendingMessage};
 use crate::meilisearch::SearchStore;
-use crate::neo4j::GraphStore;
 use crate::neo4j::models::ChatEventRecord;
+use crate::neo4j::GraphStore;
 
 /// Dependencies needed to trigger a fresh `stream_response` from an
 /// idle session when an OOB event arrives. These are all
@@ -775,7 +775,12 @@ mod tests {
         // First `cap` calls: all allowed, no warning.
         for _ in 0..cap {
             let blocked = check_and_record_trigger_cap(
-                "test-session", &events_tx, &history, cap, window, &warned,
+                "test-session",
+                &events_tx,
+                &history,
+                cap,
+                window,
+                &warned,
             )
             .await;
             assert!(!blocked, "first {cap} triggers must not be blocked");
@@ -784,7 +789,12 @@ mod tests {
         // Next 50 calls: all blocked, warning emitted exactly once.
         for _ in 0..50 {
             let blocked = check_and_record_trigger_cap(
-                "test-session", &events_tx, &history, cap, window, &warned,
+                "test-session",
+                &events_tx,
+                &history,
+                cap,
+                window,
+                &warned,
             )
             .await;
             assert!(blocked, "calls beyond cap must be blocked");
@@ -820,10 +830,8 @@ mod tests {
         // Fill the window.
         for _ in 0..cap {
             assert!(
-                !check_and_record_trigger_cap(
-                    "s", &events_tx, &history, cap, window, &warned
-                )
-                .await
+                !check_and_record_trigger_cap("s", &events_tx, &history, cap, window, &warned)
+                    .await
             );
         }
         assert!(
@@ -894,15 +902,13 @@ mod tests {
     /// Returns: (events_rx, mock_graph, handle, cancel_token).
     /// Caller must `cancel_token.cancel()` to stop the listener after the
     /// test or rely on the test's tokio runtime tearing it down.
-    async fn spawn_listener_with_mock_transport()
-        -> (
-            broadcast::Receiver<ChatEvent>,
-            Arc<crate::neo4j::mock::MockGraphStore>,
-            nexus_claude::transport::mock::MockTransportHandle,
-            CancellationToken,
-            Uuid,
-        )
-    {
+    async fn spawn_listener_with_mock_transport() -> (
+        broadcast::Receiver<ChatEvent>,
+        Arc<crate::neo4j::mock::MockGraphStore>,
+        nexus_claude::transport::mock::MockTransportHandle,
+        CancellationToken,
+        Uuid,
+    ) {
         use tokio::sync::RwLock;
 
         let (transport, handle) = nexus_claude::transport::mock::MockTransport::pair();
@@ -1067,10 +1073,7 @@ mod tests {
         // surface them in order, with monotonically-increasing seq_num
         // captured by ChatEventRecord (verified via the mock graph).
         for i in 0..3 {
-            let msg = bash_output_message(
-                "bash-bg-42",
-                &format!("background bash line {i}"),
-            );
+            let msg = bash_output_message("bash-bg-42", &format!("background bash line {i}"));
             handle
                 .inbound_message_tx
                 .send(msg)
@@ -1118,10 +1121,7 @@ mod tests {
                 .unwrap_or_default()
         };
         for w in seqs.windows(2) {
-            assert!(
-                w[0] < w[1],
-                "seq must be strictly increasing, got {seqs:?}"
-            );
+            assert!(w[0] < w[1], "seq must be strictly increasing, got {seqs:?}");
         }
 
         cancel.cancel();
@@ -1157,10 +1157,7 @@ mod tests {
                     .signed_duration_since(received_at)
                     .num_milliseconds()
                     .unsigned_abs();
-                assert!(
-                    age < 1000,
-                    "received_at must be ~now, got age = {age}ms"
-                );
+                assert!(age < 1000, "received_at must be ~now, got age = {age}ms");
             }
             other => panic!("expected SessionError, got {other:?}"),
         }

--- a/src/chat/oob_listener.rs
+++ b/src/chat/oob_listener.rs
@@ -33,40 +33,78 @@
 //! `is_streaming == false`. In-stream messages are delegated to
 //! `stream_response`'s normal handling and we silently skip them here to
 //! avoid duplicate persistence/broadcast.
+//!
+//! ## Triggering on idle
+//!
+//! When an OOB event arrives and the session is idle (no active turn),
+//! the listener:
+//!   1. Persists the event as a `ChatEventRecord` of type `background_output`
+//!      (so it appears in `chat::list_messages` history)
+//!   2. Broadcasts a `ChatEvent::BackgroundOutput` (so WebSocket clients
+//!      see it in real time)
+//!   3. Pushes a `PendingMessage::BackgroundOutput` carrying the content
+//!   4. Tries to claim the streaming flag via `compare_exchange(false, true)`
+//!      and, if it wins the race, spawns a new `stream_response` so the
+//!      LLM reacts to the event without waiting for the next user turn
+//!   5. If it loses the race (a concurrent user message claimed the
+//!      flag first), the queued `PendingMessage` will be picked up by
+//!      `drain_pending_messages` after that turn ends — no event is
+//!      dropped.
 
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 
 use chrono::Utc;
 use futures::StreamExt;
 use nexus_claude::{
     AssistantMessage, ContentBlock, ContentValue, InteractiveClient, Message, UserMessage,
 };
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, RwLock, broadcast};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
+use uuid::Uuid;
 
-use super::types::ChatEvent;
+use super::manager::{ActiveSession, ChatManager};
+use super::types::{ChatEvent, PendingMessage};
+use crate::meilisearch::SearchStore;
+use crate::neo4j::GraphStore;
+use crate::neo4j::models::ChatEventRecord;
+
+/// Dependencies needed to trigger a fresh `stream_response` from an
+/// idle session when an OOB event arrives. These are all
+/// `ChatManager`-bound (not session-bound) and are cloned once at spawn
+/// time. Session-bound state is looked up via `active_sessions` at
+/// trigger time, mirroring the pattern used by `spawn_nats_rpc_listener`.
+pub(crate) struct OobListenerDeps {
+    pub graph: Arc<dyn GraphStore>,
+    pub active_sessions: Arc<RwLock<HashMap<String, ActiveSession>>>,
+    pub context_injector: Option<Arc<nexus_claude::memory::ContextInjector>>,
+    pub event_emitter: Option<Arc<dyn crate::events::EventEmitter>>,
+    pub retry_config: super::config::RetryConfig,
+    pub enrichment_pipeline: Arc<super::enrichment::EnrichmentPipeline>,
+    pub search: Arc<dyn SearchStore>,
+    pub nats: Option<Arc<crate::events::NatsEmitter>>,
+}
 
 /// Spawn the OOB listener task for a session. Fire-and-forget — the task
 /// is owned by the tokio runtime and stops when `cancel` is fired.
 ///
 /// `session_id` is used only for tracing context.
-///
-/// `client` and `cancel` MUST outlive the task by the natural session
-/// lifecycle: when the `ActiveSession` is dropped or replaced (resume),
-/// the caller fires `cancel` and the task exits cleanly within ~100ms.
-pub fn spawn_oob_listener(
+pub(crate) fn spawn_oob_listener(
     session_id: String,
     client: Arc<Mutex<InteractiveClient>>,
     events_tx: broadcast::Sender<ChatEvent>,
     is_streaming: Arc<AtomicBool>,
+    next_seq: Arc<AtomicI64>,
     cancel: CancellationToken,
+    deps: OobListenerDeps,
 ) {
+    let session_uuid = Uuid::parse_str(&session_id).ok();
+
     tokio::spawn(async move {
         // Briefly take the client lock to call subscribe_messages(). The
-        // returned stream is `'static` and independent of the lock — the
-        // lock is released as soon as this block exits.
+        // returned stream is `'static` and independent of the lock.
         let stream = {
             let client = client.lock().await;
             client.subscribe_messages().await
@@ -97,9 +135,7 @@ pub fn spawn_oob_listener(
                     match next {
                         Some(Ok(message)) => {
                             // If a stream_response is currently running, that path
-                            // already consumes the same broadcast and converts the
-                            // message into proper ChatEvents (ToolUse, AssistantText, …).
-                            // Emitting BackgroundOutput here would duplicate the event.
+                            // already consumes the same broadcast. Skip silently.
                             if is_streaming.load(Ordering::Relaxed) {
                                 debug!(
                                     session_id = %session_id,
@@ -107,7 +143,17 @@ pub fn spawn_oob_listener(
                                 );
                                 continue;
                             }
-                            handle_oob_message(&session_id, &events_tx, &message);
+                            handle_oob_message(
+                                &session_id,
+                                session_uuid,
+                                &events_tx,
+                                &is_streaming,
+                                &next_seq,
+                                &client,
+                                &deps,
+                                &message,
+                            )
+                            .await;
                         }
                         Some(Err(e)) => {
                             warn!(
@@ -117,10 +163,6 @@ pub fn spawn_oob_listener(
                             );
                         }
                         None => {
-                            // Stream closed: the broadcast::Sender was dropped, which
-                            // means the subprocess transport is gone (CLI died or
-                            // disconnect() was called). The session is effectively
-                            // dead — let the caller know via SystemHint and exit.
                             warn!(
                                 session_id = %session_id,
                                 "OOB listener: SDK message broadcast closed (subprocess gone); exiting"
@@ -140,12 +182,17 @@ pub fn spawn_oob_listener(
     });
 }
 
-/// Convert an OOB `Message` to a `ChatEvent::BackgroundOutput` and emit it
-/// on the session's broadcast. Persistence and queueing for trigger are
-/// handled separately (T5).
-fn handle_oob_message(
+/// Handle a single OOB Message: persist, broadcast, push to queue, and
+/// try to claim the streaming flag to spawn a new turn.
+#[allow(clippy::too_many_arguments)]
+async fn handle_oob_message(
     session_id: &str,
+    session_uuid: Option<Uuid>,
     events_tx: &broadcast::Sender<ChatEvent>,
+    is_streaming: &Arc<AtomicBool>,
+    next_seq: &Arc<AtomicI64>,
+    _client: &Arc<Mutex<InteractiveClient>>,
+    deps: &OobListenerDeps,
     message: &Message,
 ) {
     let payload = extract_payload(message);
@@ -168,7 +215,7 @@ fn handle_oob_message(
 
     let event = ChatEvent::BackgroundOutput {
         source: source.clone(),
-        content,
+        content: content.clone(),
         received_at: Utc::now(),
         correlation_id,
     };
@@ -179,20 +226,184 @@ fn handle_oob_message(
         "OOB listener: emitting BackgroundOutput"
     );
 
-    // Fire-and-forget: if there are no subscribers (no WebSocket clients,
-    // no stream_response listening), the event is dropped. Persistence to
-    // the graph is added in T5/T9 — for now the broadcast is the only sink.
-    let _ = events_tx.send(event);
+    // 1. Persist as ChatEventRecord (so it appears in list_messages history)
+    if let Some(uuid) = session_uuid {
+        let record = ChatEventRecord {
+            id: Uuid::new_v4(),
+            session_id: uuid,
+            seq: next_seq.fetch_add(1, Ordering::SeqCst),
+            event_type: event.event_type().to_string(),
+            data: serde_json::to_string(&event).unwrap_or_default(),
+            created_at: chrono::Utc::now(),
+        };
+        if let Err(e) = deps.graph.store_chat_events(uuid, vec![record]).await {
+            warn!(
+                session_id = %session_id,
+                error = %e,
+                "OOB listener: failed to persist BackgroundOutput record (non-fatal)"
+            );
+        }
+    }
+
+    // 2. Broadcast on local channel + NATS so all WebSocket clients see it
+    let _ = events_tx.send(event.clone());
+    if let Some(ref nats) = deps.nats {
+        nats.publish_chat_event(session_id, event);
+    }
+
+    // 3 & 4. Push to pending_messages and try to claim streaming, then
+    //         maybe trigger a new stream_response.
+    maybe_trigger_stream(session_id, content, is_streaming, deps).await;
+}
+
+/// Push the OOB content as a `PendingMessage::BackgroundOutput` and, if
+/// the session is idle, atomically claim the streaming flag and spawn
+/// `stream_response` so the LLM reacts.
+///
+/// Race semantics: we use `compare_exchange(false, true)` on
+/// `is_streaming`. Whichever caller first transitions false→true owns
+/// the spawn; concurrent OOB events or user messages losing the race
+/// just leave their entries in the queue and the active stream's
+/// `drain_pending_messages` picks them up after Result.
+async fn maybe_trigger_stream(
+    session_id: &str,
+    oob_content: String,
+    is_streaming: &Arc<AtomicBool>,
+    deps: &OobListenerDeps,
+) {
+    // Look up session-bound state. If the session was just removed,
+    // there's nothing to do.
+    let session_state = {
+        let sessions = deps.active_sessions.read().await;
+        sessions.get(session_id).map(|s| {
+            (
+                s.client.clone(),
+                s.events_tx.clone(),
+                s.interrupt_flag.clone(),
+                s.memory_manager.clone(),
+                s.next_seq.clone(),
+                s.pending_messages.clone(),
+                s.is_streaming.clone(),
+                s.streaming_text.clone(),
+                s.streaming_events.clone(),
+                s.sdk_control_rx.clone(),
+                s.auto_continue.clone(),
+            )
+        })
+    };
+
+    let Some((
+        client,
+        events_tx,
+        interrupt_flag,
+        memory_manager,
+        next_seq,
+        pending_messages,
+        sess_is_streaming,
+        streaming_text,
+        streaming_events,
+        sdk_control_rx,
+        auto_continue,
+    )) = session_state
+    else {
+        debug!(
+            session_id = %session_id,
+            "OOB listener: session no longer in active_sessions — dropping trigger"
+        );
+        return;
+    };
+
+    // Push the OOB content as a queue entry so drain_pending_messages
+    // (or the spawned stream_response below) can process it later.
+    {
+        let mut queue = pending_messages.lock().await;
+        queue.push_back(PendingMessage::background_output(oob_content.clone()));
+    }
+
+    // Claim the streaming flag atomically. Loser leaves the message in
+    // the queue — drain will pick it up after the active turn ends.
+    let won_race = is_streaming
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok();
+
+    if !won_race {
+        debug!(
+            session_id = %session_id,
+            "OOB listener: lost is_streaming race — message queued for active stream's drain"
+        );
+        return;
+    }
+
+    info!(
+        session_id = %session_id,
+        "OOB listener: idle session, spawning stream_response for queued OOB event"
+    );
+
+    // Pop the entry we just pushed (drain will see it via the queue).
+    // Actually we WANT drain to handle it — but stream_response needs an
+    // initial prompt. Give it the OOB content directly; the queue
+    // remains for any subsequent OOB events that may have stacked up
+    // between the push and the spawn.
+    let prompt = {
+        let mut queue = pending_messages.lock().await;
+        queue.pop_front().map(|m| m.content).unwrap_or(oob_content)
+    };
+
+    // Spawn stream_response. Same call shape as in `spawn_nats_rpc_listener`.
+    let session_id_for_spawn = session_id.to_string();
+    let graph = deps.graph.clone();
+    let active_sessions = deps.active_sessions.clone();
+    let context_injector = deps.context_injector.clone();
+    let event_emitter = deps.event_emitter.clone();
+    let retry_config = deps.retry_config.clone();
+    let enrichment_pipeline = deps.enrichment_pipeline.clone();
+    let search = deps.search.clone();
+    let nats = deps.nats.clone();
+    // `client` was cloned earlier from ActiveSession but only the spawned
+    // stream_response below consumes it; touch it here to make ownership
+    // explicit without moving `sess_is_streaming`, which we still need
+    // below for the Arc::clone.
+    let _ = client.clone();
+
+    tokio::spawn(async move {
+        ChatManager::stream_response(
+            client,
+            events_tx,
+            prompt,
+            session_id_for_spawn,
+            graph,
+            active_sessions,
+            interrupt_flag,
+            memory_manager,
+            context_injector,
+            next_seq,
+            pending_messages,
+            // Pass the OUTER is_streaming flag — it's the same Arc as
+            // sess_is_streaming (cloned from the same source), but we
+            // already set it to true above so stream_response won't
+            // re-set it.
+            // SAFETY: same Arc<AtomicBool> across the session.
+            // NB: stream_response will set is_streaming=false at the
+            // end via post_stream::finalize_streaming_status.
+            std::sync::Arc::clone(&sess_is_streaming),
+            streaming_text,
+            streaming_events,
+            event_emitter,
+            nats,
+            sdk_control_rx,
+            auto_continue,
+            retry_config,
+            enrichment_pipeline,
+            search,
+        )
+        .await;
+    });
 }
 
 /// Map a `nexus_claude::Message` variant to `(source, content, correlation_id)`
 /// suitable for `ChatEvent::BackgroundOutput`. Returns `None` for variants
 /// that should be ignored at the OOB level (e.g. `Result` end-of-turn,
 /// `StreamEvent` partial tokens — these are in-stream artefacts).
-///
-/// `source` is a coarse label intended for UI categorisation; `content`
-/// is the human-readable payload; `correlation_id` is the parent tool_use
-/// ID when the message came from a sidechain (e.g. background `Task`).
 fn extract_payload(message: &Message) -> Option<(String, String, Option<String>)> {
     match message {
         Message::Assistant {
@@ -213,23 +424,14 @@ fn extract_payload(message: &Message) -> Option<(String, String, Option<String>)
         )),
         Message::System { subtype, data } => Some((
             format!("system:{subtype}"),
-            // System data is opaque JSON — surface it pretty-printed so
-            // humans can read it; the UI can collapse if too noisy.
             serde_json::to_string_pretty(data).unwrap_or_default(),
             None,
         )),
-        // Result and StreamEvent are turn-internal and shouldn't normally
-        // arrive OOB. If they do, we silently ignore them (a `Result`
-        // arriving without a turn is meaningless; a `StreamEvent` is a
-        // partial that has no value without its enclosing turn).
         Message::Result { .. } | Message::StreamEvent { .. } => None,
     }
 }
 
 fn assistant_text(m: &AssistantMessage) -> String {
-    // AssistantMessage::content is `Vec<ContentBlock>`. Concatenate text
-    // blocks; synthesise placeholders for non-text blocks so the UI sees
-    // something meaningful.
     m.content
         .iter()
         .map(|block| match block {
@@ -254,9 +456,6 @@ fn format_tool_result(t: &nexus_claude::ToolResultContent) -> String {
 }
 
 fn user_text(m: &UserMessage) -> String {
-    // UserMessage::content is a String (text content, possibly empty).
-    // UserMessage::content_blocks holds structured blocks (tool_result, ...).
-    // Concatenate both, preferring blocks when both are present.
     if let Some(blocks) = &m.content_blocks {
         let rendered: String = blocks
             .iter()
@@ -276,8 +475,6 @@ fn user_text(m: &UserMessage) -> String {
 }
 
 fn user_message_source(m: &UserMessage) -> String {
-    // If the message carries a tool_result block, label accordingly so the
-    // UI/dedup logic can distinguish from real user input.
     if let Some(blocks) = &m.content_blocks {
         for block in blocks {
             if matches!(block, ContentBlock::ToolResult(_)) {

--- a/src/chat/oob_listener.rs
+++ b/src/chat/oob_listener.rs
@@ -1,0 +1,383 @@
+//! Out-of-band SDK message listener.
+//!
+//! Background tokio task spawned per chat session that consumes the
+//! long-lived `broadcast::Sender<Message>` exposed by `nexus_claude::
+//! InteractiveClient::subscribe_messages()` and surfaces "out-of-band"
+//! events into the chat event stream.
+//!
+//! ## What is an "out-of-band" event?
+//!
+//! Any SDK [`Message`] that arrives on the broadcast while no active
+//! `stream_response` is running for the session — typically:
+//!
+//! - Background tool notifications (the `Monitor` tool firing on a
+//!   matched log line, `BashOutput` from a `run_in_background` Bash
+//!   completing, sub-Agent completion events from background `Task`s)
+//! - System notifications fired by the CLI between turns
+//!
+//! ## Architecture
+//!
+//! Spawned once per session in [`super::manager::ChatManager::create_session`]
+//! and again on [`super::manager::ChatManager::resume_session`]. The task
+//! takes a brief lock on the [`InteractiveClient`] only to call
+//! `subscribe_messages()`, which returns a `'static` stream that lives
+//! independently of the lock. The task then loops on that stream and the
+//! `cancel` token.
+//!
+//! ## Interaction with `stream_response`
+//!
+//! `stream_response` itself subscribes to the same broadcast (via
+//! `send_and_receive_stream` internally). When a turn is active, BOTH
+//! subscribers receive each `Message`. The `is_streaming` flag is the
+//! coordination signal: this listener treats messages as OOB **only** when
+//! `is_streaming == false`. In-stream messages are delegated to
+//! `stream_response`'s normal handling and we silently skip them here to
+//! avoid duplicate persistence/broadcast.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use chrono::Utc;
+use futures::StreamExt;
+use nexus_claude::{
+    AssistantMessage, ContentBlock, ContentValue, InteractiveClient, Message, UserMessage,
+};
+use tokio::sync::{Mutex, broadcast};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use super::types::ChatEvent;
+
+/// Spawn the OOB listener task for a session. Fire-and-forget — the task
+/// is owned by the tokio runtime and stops when `cancel` is fired.
+///
+/// `session_id` is used only for tracing context.
+///
+/// `client` and `cancel` MUST outlive the task by the natural session
+/// lifecycle: when the `ActiveSession` is dropped or replaced (resume),
+/// the caller fires `cancel` and the task exits cleanly within ~100ms.
+pub fn spawn_oob_listener(
+    session_id: String,
+    client: Arc<Mutex<InteractiveClient>>,
+    events_tx: broadcast::Sender<ChatEvent>,
+    is_streaming: Arc<AtomicBool>,
+    cancel: CancellationToken,
+) {
+    tokio::spawn(async move {
+        // Briefly take the client lock to call subscribe_messages(). The
+        // returned stream is `'static` and independent of the lock — the
+        // lock is released as soon as this block exits.
+        let stream = {
+            let client = client.lock().await;
+            client.subscribe_messages().await
+        };
+
+        let mut stream = match stream {
+            Some(s) => s,
+            None => {
+                warn!(
+                    session_id = %session_id,
+                    "OOB listener: subscribe_messages() returned None \
+                     (mock transport or transport not connected). \
+                     Spontaneous messages between turns will not be observed."
+                );
+                return;
+            }
+        };
+
+        info!(session_id = %session_id, "OOB listener started");
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    info!(session_id = %session_id, "OOB listener cancelled, exiting");
+                    return;
+                }
+                next = stream.next() => {
+                    match next {
+                        Some(Ok(message)) => {
+                            // If a stream_response is currently running, that path
+                            // already consumes the same broadcast and converts the
+                            // message into proper ChatEvents (ToolUse, AssistantText, …).
+                            // Emitting BackgroundOutput here would duplicate the event.
+                            if is_streaming.load(Ordering::Relaxed) {
+                                debug!(
+                                    session_id = %session_id,
+                                    "OOB listener: in-stream message — skipping (stream_response handles it)"
+                                );
+                                continue;
+                            }
+                            handle_oob_message(&session_id, &events_tx, &message);
+                        }
+                        Some(Err(e)) => {
+                            warn!(
+                                session_id = %session_id,
+                                error = %e,
+                                "OOB listener: error reading from broadcast stream"
+                            );
+                        }
+                        None => {
+                            // Stream closed: the broadcast::Sender was dropped, which
+                            // means the subprocess transport is gone (CLI died or
+                            // disconnect() was called). The session is effectively
+                            // dead — let the caller know via SystemHint and exit.
+                            warn!(
+                                session_id = %session_id,
+                                "OOB listener: SDK message broadcast closed (subprocess gone); exiting"
+                            );
+                            let _ = events_tx.send(ChatEvent::SystemHint {
+                                content: "The CLI subprocess for this session has exited. \
+                                          Send a message to start a new turn (will resume \
+                                          the session if possible)."
+                                    .into(),
+                            });
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Convert an OOB `Message` to a `ChatEvent::BackgroundOutput` and emit it
+/// on the session's broadcast. Persistence and queueing for trigger are
+/// handled separately (T5).
+fn handle_oob_message(
+    session_id: &str,
+    events_tx: &broadcast::Sender<ChatEvent>,
+    message: &Message,
+) {
+    let payload = extract_payload(message);
+    let Some((source, content, correlation_id)) = payload else {
+        debug!(
+            session_id = %session_id,
+            "OOB listener: message variant produced no payload — skipping"
+        );
+        return;
+    };
+
+    if content.trim().is_empty() {
+        debug!(
+            session_id = %session_id,
+            source = %source,
+            "OOB listener: empty content payload — skipping"
+        );
+        return;
+    }
+
+    let event = ChatEvent::BackgroundOutput {
+        source: source.clone(),
+        content,
+        received_at: Utc::now(),
+        correlation_id,
+    };
+
+    info!(
+        session_id = %session_id,
+        source = %source,
+        "OOB listener: emitting BackgroundOutput"
+    );
+
+    // Fire-and-forget: if there are no subscribers (no WebSocket clients,
+    // no stream_response listening), the event is dropped. Persistence to
+    // the graph is added in T5/T9 — for now the broadcast is the only sink.
+    let _ = events_tx.send(event);
+}
+
+/// Map a `nexus_claude::Message` variant to `(source, content, correlation_id)`
+/// suitable for `ChatEvent::BackgroundOutput`. Returns `None` for variants
+/// that should be ignored at the OOB level (e.g. `Result` end-of-turn,
+/// `StreamEvent` partial tokens — these are in-stream artefacts).
+///
+/// `source` is a coarse label intended for UI categorisation; `content`
+/// is the human-readable payload; `correlation_id` is the parent tool_use
+/// ID when the message came from a sidechain (e.g. background `Task`).
+fn extract_payload(message: &Message) -> Option<(String, String, Option<String>)> {
+    match message {
+        Message::Assistant {
+            message: m,
+            parent_tool_use_id,
+        } => Some((
+            "assistant".to_string(),
+            assistant_text(m),
+            parent_tool_use_id.clone(),
+        )),
+        Message::User {
+            message: m,
+            parent_tool_use_id,
+        } => Some((
+            user_message_source(m),
+            user_text(m),
+            parent_tool_use_id.clone(),
+        )),
+        Message::System { subtype, data } => Some((
+            format!("system:{subtype}"),
+            // System data is opaque JSON — surface it pretty-printed so
+            // humans can read it; the UI can collapse if too noisy.
+            serde_json::to_string_pretty(data).unwrap_or_default(),
+            None,
+        )),
+        // Result and StreamEvent are turn-internal and shouldn't normally
+        // arrive OOB. If they do, we silently ignore them (a `Result`
+        // arriving without a turn is meaningless; a `StreamEvent` is a
+        // partial that has no value without its enclosing turn).
+        Message::Result { .. } | Message::StreamEvent { .. } => None,
+    }
+}
+
+fn assistant_text(m: &AssistantMessage) -> String {
+    // AssistantMessage::content is `Vec<ContentBlock>`. Concatenate text
+    // blocks; synthesise placeholders for non-text blocks so the UI sees
+    // something meaningful.
+    m.content
+        .iter()
+        .map(|block| match block {
+            ContentBlock::Text(t) => t.text.clone(),
+            ContentBlock::Thinking(t) => format!("[thinking] {}", t.thinking),
+            ContentBlock::ToolUse(t) => format!("[tool_use: {}]", t.name),
+            ContentBlock::ToolResult(t) => format_tool_result(t),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_tool_result(t: &nexus_claude::ToolResultContent) -> String {
+    match &t.content {
+        Some(ContentValue::Text(s)) => format!("[tool_result] {s}"),
+        Some(ContentValue::Structured(blocks)) => {
+            let payload = serde_json::to_string(blocks).unwrap_or_default();
+            format!("[tool_result] {payload}")
+        }
+        None => "[tool_result]".to_string(),
+    }
+}
+
+fn user_text(m: &UserMessage) -> String {
+    // UserMessage::content is a String (text content, possibly empty).
+    // UserMessage::content_blocks holds structured blocks (tool_result, ...).
+    // Concatenate both, preferring blocks when both are present.
+    if let Some(blocks) = &m.content_blocks {
+        let rendered: String = blocks
+            .iter()
+            .map(|block| match block {
+                ContentBlock::Text(t) => t.text.clone(),
+                ContentBlock::Thinking(t) => format!("[thinking] {}", t.thinking),
+                ContentBlock::ToolUse(t) => format!("[tool_use: {}]", t.name),
+                ContentBlock::ToolResult(t) => format_tool_result(t),
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        if !rendered.trim().is_empty() {
+            return rendered;
+        }
+    }
+    m.content.clone()
+}
+
+fn user_message_source(m: &UserMessage) -> String {
+    // If the message carries a tool_result block, label accordingly so the
+    // UI/dedup logic can distinguish from real user input.
+    if let Some(blocks) = &m.content_blocks {
+        for block in blocks {
+            if matches!(block, ContentBlock::ToolResult(_)) {
+                return "tool_result".to_string();
+            }
+        }
+    }
+    "user".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nexus_claude::{TextContent, ToolResultContent};
+    use serde_json::json;
+
+    fn user_with_blocks(blocks: Vec<ContentBlock>) -> Message {
+        Message::User {
+            message: UserMessage {
+                content: String::new(),
+                content_blocks: Some(blocks),
+            },
+            parent_tool_use_id: Some("tool-bg-123".to_string()),
+        }
+    }
+
+    fn user_plain(text: &str) -> Message {
+        Message::User {
+            message: UserMessage {
+                content: text.to_string(),
+                content_blocks: None,
+            },
+            parent_tool_use_id: None,
+        }
+    }
+
+    #[test]
+    fn test_extract_payload_ignores_result_and_stream_event() {
+        let result_msg = Message::Result {
+            subtype: "ok".into(),
+            duration_ms: 0,
+            duration_api_ms: 0,
+            is_error: false,
+            num_turns: 1,
+            session_id: "s".into(),
+            total_cost_usd: None,
+            usage: None,
+            result: None,
+            structured_output: None,
+        };
+        assert!(extract_payload(&result_msg).is_none());
+    }
+
+    #[test]
+    fn test_extract_payload_user_tool_result_labels_source() {
+        let msg = user_with_blocks(vec![ContentBlock::ToolResult(ToolResultContent {
+            tool_use_id: "t1".into(),
+            content: Some(ContentValue::Text("epoch 50 cos=0.871".into())),
+            is_error: Some(false),
+        })]);
+        let (source, content, corr) = extract_payload(&msg).expect("user message yields payload");
+        assert_eq!(source, "tool_result");
+        assert!(
+            content.contains("epoch 50 cos=0.871"),
+            "content should include tool_result text, got: {content}"
+        );
+        assert_eq!(corr.as_deref(), Some("tool-bg-123"));
+    }
+
+    #[test]
+    fn test_extract_payload_user_plain_string() {
+        let msg = user_plain("hello world");
+        let (source, content, _) = extract_payload(&msg).expect("user message yields payload");
+        assert_eq!(source, "user");
+        assert_eq!(content, "hello world");
+    }
+
+    #[test]
+    fn test_extract_payload_system_renders_data() {
+        let msg = Message::System {
+            subtype: "notification".into(),
+            data: json!({"level": "info", "text": "training done"}),
+        };
+        let (source, content, _) = extract_payload(&msg).expect("system message yields payload");
+        assert_eq!(source, "system:notification");
+        assert!(content.contains("training done"));
+    }
+
+    #[test]
+    fn test_assistant_text_concatenates_blocks() {
+        let m = AssistantMessage {
+            content: vec![
+                ContentBlock::Text(TextContent {
+                    text: "Hello".into(),
+                }),
+                ContentBlock::Text(TextContent {
+                    text: "world".into(),
+                }),
+            ],
+        };
+        assert_eq!(assistant_text(&m), "Hello\nworld");
+    }
+}

--- a/src/chat/oob_listener.rs
+++ b/src/chat/oob_listener.rs
@@ -92,6 +92,27 @@ pub(crate) struct OobListenerDeps {
 /// is owned by the tokio runtime and stops when `cancel` is fired.
 ///
 /// `session_id` is used only for tracing context.
+///
+/// ## Recovery semantics (T9 of plan 9a1684b2)
+///
+/// Recovery of interrupted runs at server boot — handled by
+/// `crate::runner::runner::Runner::recover_interrupted_runs` — does **not**
+/// need a dedicated `respawn_oob_listener` API. That recovery path
+/// re-enters the normal session lifecycle:
+///
+///   `recover_interrupted_runs → execute_plan → ChatManager::create_session
+///    → spawn_oob_listener (this function)`
+///
+/// Each restored runner session therefore gets its own fresh OOB
+/// listener bound to a freshly spawned `InteractiveClient`, identical
+/// to a never-interrupted session. The original cancellation token of
+/// the pre-crash listener is gone with the process — there's nothing to
+/// cancel — so we just spawn a new one.
+///
+/// `resume_session` (used when the user reconnects to an existing
+/// `cli_session_id` mid-conversation) follows the same pattern: the old
+/// `nats_cancel` token is fired before the new session is built, so any
+/// stale listener exits cleanly before the new one starts.
 pub(crate) fn spawn_oob_listener(
     session_id: String,
     client: Arc<Mutex<InteractiveClient>>,
@@ -164,16 +185,7 @@ pub(crate) fn spawn_oob_listener(
                             );
                         }
                         None => {
-                            warn!(
-                                session_id = %session_id,
-                                "OOB listener: SDK message broadcast closed (subprocess gone); exiting"
-                            );
-                            let _ = events_tx.send(ChatEvent::SystemHint {
-                                content: "The CLI subprocess for this session has exited. \
-                                          Send a message to start a new turn (will resume \
-                                          the session if possible)."
-                                    .into(),
-                            });
+                            emit_subprocess_death(&session_id, &events_tx);
                             return;
                         }
                     }
@@ -224,10 +236,14 @@ async fn handle_oob_message(
     info!(
         session_id = %session_id,
         source = %source,
+        oob_event_type = "background_output",
         "OOB listener: emitting BackgroundOutput"
     );
 
-    // 1. Persist as ChatEventRecord (so it appears in list_messages history)
+    // 1. Persist as ChatEventRecord (so it appears in list_messages history).
+    // Time the round-trip — `oob_persistence_latency_ms` is a structured
+    // tracing field that log-based metrics pipelines (e.g. Vector/Loki/
+    // Datadog) can extract as a histogram for production monitoring (T9).
     if let Some(uuid) = session_uuid {
         let record = ChatEventRecord {
             id: Uuid::new_v4(),
@@ -237,12 +253,27 @@ async fn handle_oob_message(
             data: serde_json::to_string(&event).unwrap_or_default(),
             created_at: chrono::Utc::now(),
         };
-        if let Err(e) = deps.graph.store_chat_events(uuid, vec![record]).await {
-            warn!(
-                session_id = %session_id,
-                error = %e,
-                "OOB listener: failed to persist BackgroundOutput record (non-fatal)"
-            );
+        let persist_start = Instant::now();
+        match deps.graph.store_chat_events(uuid, vec![record]).await {
+            Ok(_) => {
+                let latency_ms = persist_start.elapsed().as_millis() as u64;
+                debug!(
+                    session_id = %session_id,
+                    source = %source,
+                    oob_persistence_latency_ms = latency_ms,
+                    "OOB listener: persisted BackgroundOutput record"
+                );
+            }
+            Err(e) => {
+                let latency_ms = persist_start.elapsed().as_millis() as u64;
+                warn!(
+                    session_id = %session_id,
+                    source = %source,
+                    oob_persistence_latency_ms = latency_ms,
+                    error = %e,
+                    "OOB listener: failed to persist BackgroundOutput record (non-fatal)"
+                );
+            }
         }
     }
 
@@ -364,8 +395,15 @@ async fn maybe_trigger_stream(
         return;
     }
 
+    // T9 — Structured trigger log. `oob_trigger_count` is a structured
+    // tracing field (sliding-window depth at the moment of trigger),
+    // suitable for a counter via log-based metrics. Pair with the cap
+    // for a `oob_cap_utilization = count / cap` derived metric.
+    let trigger_count = oob_trigger_history.lock().await.len();
     info!(
         session_id = %session_id,
+        oob_trigger_count = trigger_count,
+        oob_trigger_cap = oob_trigger_cap,
         "OOB listener: idle session, spawning stream_response for queued OOB event"
     );
 
@@ -427,6 +465,34 @@ async fn maybe_trigger_stream(
             search,
         )
         .await;
+    });
+}
+
+/// Emit a `ChatEvent::SessionError` describing subprocess death and log
+/// a `warn!` (T9 of plan 9a1684b2). Extracted as a small helper so the
+/// behaviour is unit-testable without spinning up a real
+/// `InteractiveClient` and the full broadcast machinery.
+///
+/// Called from the listener loop's `None` branch — when
+/// `stream.next()` yields `None` the SDK transport's broadcast sender
+/// has been dropped, which means the CLI subprocess for this session
+/// has exited (clean shutdown OR crash). Subsequent `send_message`
+/// calls on this `session_id` will silently no-op until the session is
+/// recreated, so we surface a typed event the frontend can render
+/// prominently.
+fn emit_subprocess_death(session_id: &str, events_tx: &broadcast::Sender<ChatEvent>) {
+    warn!(
+        session_id = %session_id,
+        reason = "subprocess_exited",
+        "OOB listener: SDK message broadcast closed (subprocess gone); exiting"
+    );
+    let _ = events_tx.send(ChatEvent::SessionError {
+        reason: "subprocess_exited".to_string(),
+        message: "The CLI subprocess for this session has exited. \
+                  Send a message to start a new turn (will resume \
+                  the session if possible)."
+            .into(),
+        received_at: Utc::now(),
     });
 }
 
@@ -817,5 +883,45 @@ mod tests {
             2,
             "expected two warnings (one per cap-hit episode), got: {warnings:?}"
         );
+    }
+
+    // ── T9: subprocess death detection ──────────────────────────────────
+
+    /// `emit_subprocess_death` must publish exactly one
+    /// `ChatEvent::SessionError` with `reason = "subprocess_exited"` and
+    /// a non-empty user-facing message. The frontend uses the `reason`
+    /// field for routing (e.g., "transport_lost" vs "broadcast_dropped"
+    /// in future variants), so the string is part of the public contract.
+    #[tokio::test]
+    async fn test_emit_subprocess_death_emits_session_error() {
+        let (events_tx, mut rx) = broadcast::channel(8);
+        emit_subprocess_death("session-123", &events_tx);
+
+        // The send must have produced exactly one event.
+        let received = rx.try_recv().expect("expected one event on broadcast");
+        match received {
+            ChatEvent::SessionError {
+                reason,
+                message,
+                received_at,
+            } => {
+                assert_eq!(reason, "subprocess_exited");
+                assert!(
+                    message.contains("CLI subprocess"),
+                    "message must mention the subprocess for the user, got: {message}"
+                );
+                // Sanity: timestamp is within the last second.
+                let age = chrono::Utc::now()
+                    .signed_duration_since(received_at)
+                    .num_milliseconds()
+                    .unsigned_abs();
+                assert!(
+                    age < 1000,
+                    "received_at must be ~now, got age = {age}ms"
+                );
+            }
+            other => panic!("expected SessionError, got {other:?}"),
+        }
+        assert!(rx.try_recv().is_err(), "no further events expected");
     }
 }

--- a/src/chat/oob_listener.rs
+++ b/src/chat/oob_listener.rs
@@ -885,6 +885,248 @@ mod tests {
         );
     }
 
+    // ── T8: end-to-end via MockTransport ────────────────────────────────
+
+    /// Build a fully-wired OOB listener spawn using `MockTransport` so we
+    /// can drive the entire pipeline (transport broadcast → listener →
+    /// persist → events_tx) without launching a real Claude CLI.
+    ///
+    /// Returns: (events_rx, mock_graph, handle, cancel_token).
+    /// Caller must `cancel_token.cancel()` to stop the listener after the
+    /// test or rely on the test's tokio runtime tearing it down.
+    async fn spawn_listener_with_mock_transport()
+        -> (
+            broadcast::Receiver<ChatEvent>,
+            Arc<crate::neo4j::mock::MockGraphStore>,
+            nexus_claude::transport::mock::MockTransportHandle,
+            CancellationToken,
+            Uuid,
+        )
+    {
+        use tokio::sync::RwLock;
+
+        let (transport, handle) = nexus_claude::transport::mock::MockTransport::pair();
+        let mut client = InteractiveClient::from_transport(transport);
+        client.connect().await.expect("mock client connect");
+        let client = Arc::new(Mutex::new(client));
+
+        let (events_tx, events_rx) = broadcast::channel::<ChatEvent>(64);
+        let is_streaming = Arc::new(AtomicBool::new(false));
+        let next_seq = Arc::new(AtomicI64::new(1));
+        let cancel = CancellationToken::new();
+
+        let graph = Arc::new(crate::neo4j::mock::MockGraphStore::new());
+        let search = Arc::new(crate::meilisearch::mock::MockSearchStore::new());
+        let enrichment_pipeline = Arc::new(crate::chat::enrichment::EnrichmentPipeline::new(
+            crate::chat::enrichment::EnrichmentConfig::default(),
+        ));
+        let active_sessions = Arc::new(RwLock::new(HashMap::new()));
+
+        let deps = OobListenerDeps {
+            graph: graph.clone(),
+            active_sessions,
+            context_injector: None,
+            event_emitter: None,
+            retry_config: crate::chat::config::RetryConfig::default(),
+            enrichment_pipeline,
+            search,
+            nats: None,
+        };
+
+        // session_id MUST be a UUID for the persistence branch to fire
+        // (Uuid::parse_str().ok() is the gate inside handle_oob_message).
+        let session_uuid = Uuid::new_v4();
+
+        spawn_oob_listener(
+            session_uuid.to_string(),
+            client,
+            events_tx,
+            is_streaming,
+            next_seq,
+            cancel.clone(),
+            deps,
+        );
+
+        // Give the spawned task a tick to subscribe to the broadcast
+        // before we inject — otherwise the first message races and is lost
+        // on the broadcast lag.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        (events_rx, graph, handle, cancel, session_uuid)
+    }
+
+    /// Build a Message that resembles what the CLI would emit when the
+    /// `Monitor` tool fires its `match_found` notification between turns
+    /// (User message carrying a ToolResult content block keyed on the
+    /// parent tool_use_id of the original Monitor invocation).
+    fn monitor_match_message(parent: &str, line: &str) -> Message {
+        Message::User {
+            message: UserMessage {
+                content: String::new(),
+                content_blocks: Some(vec![ContentBlock::ToolResult(ToolResultContent {
+                    tool_use_id: parent.to_string(),
+                    content: Some(ContentValue::Text(line.to_string())),
+                    is_error: Some(false),
+                })]),
+            },
+            parent_tool_use_id: Some(parent.to_string()),
+        }
+    }
+
+    /// Same shape but mimicking `BashOutput` from a `Bash run_in_background`
+    /// completion — both end up routed through the User+ToolResult path
+    /// in the SDK message stream.
+    fn bash_output_message(parent: &str, output: &str) -> Message {
+        Message::User {
+            message: UserMessage {
+                content: String::new(),
+                content_blocks: Some(vec![ContentBlock::ToolResult(ToolResultContent {
+                    tool_use_id: parent.to_string(),
+                    content: Some(ContentValue::Text(output.to_string())),
+                    is_error: Some(false),
+                })]),
+            },
+            parent_tool_use_id: Some(parent.to_string()),
+        }
+    }
+
+    /// Wait for the next BackgroundOutput on the broadcast, with a hard
+    /// 500 ms ceiling (T8 acceptance criterion: events must arrive in
+    /// under 500 ms). Returns the elapsed latency.
+    async fn await_background_output(
+        rx: &mut broadcast::Receiver<ChatEvent>,
+    ) -> (ChatEvent, Duration) {
+        let start = Instant::now();
+        let event = tokio::time::timeout(Duration::from_millis(500), async {
+            loop {
+                match rx.recv().await {
+                    Ok(ev) if matches!(ev, ChatEvent::BackgroundOutput { .. }) => return ev,
+                    Ok(_) => continue, // skip non-OOB events (SystemHint init, etc.)
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => {
+                        panic!("broadcast closed before BackgroundOutput arrived")
+                    }
+                }
+            }
+        })
+        .await
+        .expect("BackgroundOutput must arrive within 500 ms");
+        (event, start.elapsed())
+    }
+
+    /// E2E — Monitor scenario. Inject a Monitor `match_found` Message
+    /// into the mock transport and verify the listener surfaces it as
+    /// `ChatEvent::BackgroundOutput` on the session broadcast within
+    /// 500 ms (acceptance criterion of T8 / plan 9a1684b2).
+    #[tokio::test]
+    async fn test_e2e_monitor_event_propagates_to_broadcast() {
+        let (mut events_rx, _graph, handle, cancel, _sid) =
+            spawn_listener_with_mock_transport().await;
+
+        // Inject — same shape the CLI would emit when Monitor matches.
+        let msg = monitor_match_message("monitor-tool-1", "epoch 50 cos=0.871");
+        handle
+            .inbound_message_tx
+            .send(msg)
+            .expect("inject Monitor message");
+
+        let (event, latency) = await_background_output(&mut events_rx).await;
+        eprintln!("[T8 latency report] Monitor → broadcast: {latency:?}");
+
+        match event {
+            ChatEvent::BackgroundOutput {
+                source,
+                content,
+                correlation_id,
+                ..
+            } => {
+                assert_eq!(source, "tool_result");
+                assert!(content.contains("epoch 50 cos=0.871"));
+                assert_eq!(correlation_id.as_deref(), Some("monitor-tool-1"));
+            }
+            other => panic!("expected BackgroundOutput, got {other:?}"),
+        }
+        assert!(
+            latency < Duration::from_millis(500),
+            "T8 latency criterion violated: {latency:?} >= 500ms"
+        );
+
+        cancel.cancel();
+    }
+
+    /// E2E — BashOutput scenario. A `Bash run_in_background` task that
+    /// completes after several seconds emits a User+ToolResult message
+    /// with the captured stdout. Same routing as Monitor. Verifies
+    /// chronological ordering of consecutive OOB events on the broadcast.
+    #[tokio::test]
+    async fn test_e2e_bash_output_chronological_ordering() {
+        let (mut events_rx, graph, handle, cancel, session_uuid) =
+            spawn_listener_with_mock_transport().await;
+
+        // Inject 3 BashOutput events in sequence. The listener must
+        // surface them in order, with monotonically-increasing seq_num
+        // captured by ChatEventRecord (verified via the mock graph).
+        for i in 0..3 {
+            let msg = bash_output_message(
+                "bash-bg-42",
+                &format!("background bash line {i}"),
+            );
+            handle
+                .inbound_message_tx
+                .send(msg)
+                .expect("inject BashOutput message");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let mut received_contents: Vec<String> = Vec::new();
+        for _ in 0..3 {
+            let (event, latency) = await_background_output(&mut events_rx).await;
+            eprintln!("[T8 latency report] BashOutput → broadcast: {latency:?}");
+            if let ChatEvent::BackgroundOutput { content, .. } = event {
+                received_contents.push(content);
+            }
+        }
+
+        assert_eq!(received_contents.len(), 3);
+        for (i, content) in received_contents.iter().enumerate() {
+            assert!(
+                content.contains(&format!("background bash line {i}")),
+                "out-of-order: position {i} content was {content:?}"
+            );
+        }
+
+        // Persistence check: the mock graph should have received exactly
+        // 3 ChatEventRecords on the persist branch. Allow a brief settle
+        // time for the persist write to complete after the broadcast.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let stored = {
+            let map = graph.chat_events.read().await;
+            map.get(&session_uuid).map(|v| v.len()).unwrap_or(0)
+        };
+        assert_eq!(
+            stored, 3,
+            "expected exactly 3 ChatEventRecord persisted, got {stored}"
+        );
+
+        // Verify the persisted records have monotonically-increasing seq
+        // — this is the chronological ordering invariant on which
+        // chat::list_messages depends.
+        let seqs: Vec<i64> = {
+            let map = graph.chat_events.read().await;
+            map.get(&session_uuid)
+                .map(|v| v.iter().map(|r| r.seq).collect())
+                .unwrap_or_default()
+        };
+        for w in seqs.windows(2) {
+            assert!(
+                w[0] < w[1],
+                "seq must be strictly increasing, got {seqs:?}"
+            );
+        }
+
+        cancel.cancel();
+    }
+
     // ── T9: subprocess death detection ──────────────────────────────────
 
     /// `emit_subprocess_death` must publish exactly one

--- a/src/chat/oob_listener.rs
+++ b/src/chat/oob_listener.rs
@@ -51,9 +51,10 @@
 //!      `drain_pending_messages` after that turn ends — no event is
 //!      dropped.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use futures::StreamExt;
@@ -288,6 +289,10 @@ async fn maybe_trigger_stream(
                 s.streaming_events.clone(),
                 s.sdk_control_rx.clone(),
                 s.auto_continue.clone(),
+                s.oob_trigger_history.clone(),
+                s.oob_trigger_cap,
+                s.oob_trigger_window,
+                s.oob_capped_warned.clone(),
             )
         })
     };
@@ -304,6 +309,10 @@ async fn maybe_trigger_stream(
         streaming_events,
         sdk_control_rx,
         auto_continue,
+        oob_trigger_history,
+        oob_trigger_cap,
+        oob_trigger_window,
+        oob_capped_warned,
     )) = session_state
     else {
         debug!(
@@ -312,6 +321,27 @@ async fn maybe_trigger_stream(
         );
         return;
     };
+
+    // T7 — Rate cap (sliding window) on OOB-driven `stream_response` spawns.
+    // Drains entries older than the window, then either blocks (cap hit)
+    // or records a fresh timestamp. Blocking ALSO skips queueing the
+    // PendingMessage::BackgroundOutput so the queue cannot be flooded
+    // and dumped into the next user-driven turn — the OOB event is
+    // still persisted+broadcast (already done in `handle_oob_message`).
+    if check_and_record_trigger_cap(
+        session_id,
+        &events_tx,
+        &oob_trigger_history,
+        oob_trigger_cap,
+        oob_trigger_window,
+        &oob_capped_warned,
+    )
+    .await
+    {
+        // Cap hit — refuse to queue + spawn. Warning already emitted
+        // (at most once per window) by the helper.
+        return;
+    }
 
     // Push the OOB content as a queue entry so drain_pending_messages
     // (or the spawned stream_response below) can process it later.
@@ -398,6 +428,76 @@ async fn maybe_trigger_stream(
         )
         .await;
     });
+}
+
+/// Sliding-window rate cap for OOB-driven `stream_response` spawns
+/// (T7 of plan 9a1684b2). Returns `true` when the trigger should be
+/// **blocked** (cap hit), `false` when it can proceed.
+///
+/// Behaviour:
+/// 1. Lock the history deque, drain timestamps older than `window`.
+/// 2. If `len >= cap`: emit a `ChatEvent::SystemHint` warning **at most
+///    once per window** (gated by `capped_warned`), log a warn, return
+///    `true`.
+/// 3. Otherwise: clear the `capped_warned` flag (we're back below the
+///    cap), push `Instant::now()`, return `false`.
+async fn check_and_record_trigger_cap(
+    session_id: &str,
+    events_tx: &broadcast::Sender<ChatEvent>,
+    history: &Arc<Mutex<VecDeque<Instant>>>,
+    cap: u32,
+    window: Duration,
+    capped_warned: &Arc<AtomicBool>,
+) -> bool {
+    let mut hist = history.lock().await;
+    let now = Instant::now();
+
+    // Drain entries older than `window`. Since timestamps are pushed in
+    // chronological order, popping from the front while the head is too
+    // old is sufficient.
+    while let Some(front) = hist.front() {
+        if now.duration_since(*front) > window {
+            hist.pop_front();
+        } else {
+            break;
+        }
+    }
+
+    if (hist.len() as u32) >= cap {
+        // Capped. Emit warning once per window via the AtomicBool gate.
+        if capped_warned
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            let warn_msg = format!(
+                "⚠️ OOB auto-continue cap reached: {} background-triggered turns in the last \
+                 {}s. Further background events will be persisted but will NOT auto-restart \
+                 the agent until activity slows down. Send a message to continue manually \
+                 if needed.",
+                cap,
+                window.as_secs()
+            );
+            warn!(
+                session_id = %session_id,
+                cap = cap,
+                window_secs = window.as_secs(),
+                "OOB listener: trigger cap reached, throttling further auto-continues"
+            );
+            let _ = events_tx.send(ChatEvent::SystemHint { content: warn_msg });
+        } else {
+            debug!(
+                session_id = %session_id,
+                "OOB listener: trigger still capped (warning already emitted)"
+            );
+        }
+        return true;
+    }
+
+    // Below cap — clear the warned flag (so a new spike will re-warn)
+    // and record this trigger.
+    capped_warned.store(false, Ordering::SeqCst);
+    hist.push_back(now);
+    false
 }
 
 /// Map a `nexus_claude::Message` variant to `(source, content, correlation_id)`
@@ -576,5 +676,146 @@ mod tests {
             ],
         };
         assert_eq!(assistant_text(&m), "Hello\nworld");
+    }
+
+    // ── T7: trigger cap (sliding window) tests ──────────────────────────
+
+    /// Subscribe to the broadcast and collect all SystemHint warnings
+    /// received during the closure's execution.
+    async fn collect_warnings(
+        events_tx: &broadcast::Sender<ChatEvent>,
+    ) -> tokio::sync::mpsc::UnboundedReceiver<String> {
+        let mut rx = events_tx.subscribe();
+        let (tx, out_rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            while let Ok(ev) = rx.recv().await {
+                if let ChatEvent::SystemHint { content } = ev {
+                    let _ = tx.send(content);
+                }
+            }
+        });
+        out_rx
+    }
+
+    #[tokio::test]
+    async fn test_trigger_cap_blocks_after_cap_and_warns_once() {
+        let (events_tx, _rx_keep) = broadcast::channel(64);
+        let mut warn_rx = collect_warnings(&events_tx).await;
+        let history = Arc::new(Mutex::new(VecDeque::<Instant>::new()));
+        let cap: u32 = 3;
+        let window = Duration::from_secs(60);
+        let warned = Arc::new(AtomicBool::new(false));
+
+        // First `cap` calls: all allowed, no warning.
+        for _ in 0..cap {
+            let blocked = check_and_record_trigger_cap(
+                "test-session", &events_tx, &history, cap, window, &warned,
+            )
+            .await;
+            assert!(!blocked, "first {cap} triggers must not be blocked");
+        }
+
+        // Next 50 calls: all blocked, warning emitted exactly once.
+        for _ in 0..50 {
+            let blocked = check_and_record_trigger_cap(
+                "test-session", &events_tx, &history, cap, window, &warned,
+            )
+            .await;
+            assert!(blocked, "calls beyond cap must be blocked");
+        }
+
+        // Drain warnings — give the spawn loop a tick to flush.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let mut warnings = Vec::new();
+        while let Ok(w) = warn_rx.try_recv() {
+            warnings.push(w);
+        }
+        assert_eq!(
+            warnings.len(),
+            1,
+            "expected exactly one warning emitted per window, got: {warnings:?}"
+        );
+        assert!(
+            warnings[0].contains("OOB auto-continue cap reached"),
+            "warning content unexpected: {}",
+            warnings[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trigger_cap_drops_old_entries() {
+        let (events_tx, _rx_keep) = broadcast::channel(16);
+        let history = Arc::new(Mutex::new(VecDeque::<Instant>::new()));
+        let cap: u32 = 2;
+        // Tiny window so we can age entries out in test time.
+        let window = Duration::from_millis(50);
+        let warned = Arc::new(AtomicBool::new(false));
+
+        // Fill the window.
+        for _ in 0..cap {
+            assert!(
+                !check_and_record_trigger_cap(
+                    "s", &events_tx, &history, cap, window, &warned
+                )
+                .await
+            );
+        }
+        assert!(
+            check_and_record_trigger_cap("s", &events_tx, &history, cap, window, &warned).await,
+            "cap should be hit"
+        );
+
+        // Wait past the window.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+
+        // Now the window is empty again — should accept fresh triggers
+        // and re-arm the warning gate.
+        assert!(
+            !check_and_record_trigger_cap("s", &events_tx, &history, cap, window, &warned).await,
+            "after window expiry, triggers should be accepted again"
+        );
+        assert!(
+            !warned.load(Ordering::SeqCst),
+            "warned flag must reset when below cap again"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trigger_cap_warning_rearms_after_recovery() {
+        let (events_tx, _rx_keep) = broadcast::channel(16);
+        let mut warn_rx = collect_warnings(&events_tx).await;
+        let history = Arc::new(Mutex::new(VecDeque::<Instant>::new()));
+        let cap: u32 = 1;
+        let window = Duration::from_millis(50);
+        let warned = Arc::new(AtomicBool::new(false));
+
+        // Hit the cap — first call OK, second blocked + warns.
+        assert!(
+            !check_and_record_trigger_cap("s", &events_tx, &history, cap, window, &warned).await
+        );
+        assert!(
+            check_and_record_trigger_cap("s", &events_tx, &history, cap, window, &warned).await
+        );
+        // Wait past window so entries drop.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        // First post-recovery call accepted, clears warned.
+        assert!(
+            !check_and_record_trigger_cap("s", &events_tx, &history, cap, window, &warned).await
+        );
+        // Hit cap again — should re-warn (not silently swallow).
+        assert!(
+            check_and_record_trigger_cap("s", &events_tx, &history, cap, window, &warned).await
+        );
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let mut warnings = Vec::new();
+        while let Ok(w) = warn_rx.try_recv() {
+            warnings.push(w);
+        }
+        assert_eq!(
+            warnings.len(),
+            2,
+            "expected two warnings (one per cap-hit episode), got: {warnings:?}"
+        );
     }
 }

--- a/src/chat/post_stream.rs
+++ b/src/chat/post_stream.rs
@@ -1093,6 +1093,12 @@ mod integration_tests {
                 objective_reminder_turns_since: Arc::new(AtomicU32::new(0)),
                 reasoning_path_tracker: crate::chat::feedback::ReasoningPathTracker::new(),
                 work_log: Arc::new(Mutex::new(crate::chat::types::SessionWorkLog::default())),
+                oob_trigger_history: Arc::new(Mutex::new(VecDeque::new())),
+                oob_trigger_cap: crate::chat::manager::OOB_TRIGGER_CAP_INTERACTIVE,
+                oob_trigger_window: std::time::Duration::from_secs(
+                    crate::chat::manager::OOB_TRIGGER_WINDOW_SECS,
+                ),
+                oob_capped_warned: Arc::new(AtomicBool::new(false)),
             };
             active_sessions
                 .write()

--- a/src/chat/types.rs
+++ b/src/chat/types.rs
@@ -449,6 +449,30 @@ pub enum ChatEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         correlation_id: Option<String>,
     },
+    /// A session-level error that requires the user's attention — the CLI
+    /// subprocess is gone, the transport is broken, or the session is
+    /// otherwise unrecoverable without a fresh `create_session` /
+    /// `resume_session` round-trip.
+    ///
+    /// Distinct from `Error`, which is used for in-stream tool errors
+    /// recoverable mid-turn. `SessionError` signals that subsequent
+    /// messages on this session_id will silently no-op until the user
+    /// (or runner) explicitly restarts the session — frontends should
+    /// surface this prominently.
+    ///
+    /// T9 of plan 9a1684b2 — emitted by `chat::oob_listener` when its
+    /// stream returns `None` (broadcast closed because the SDK transport
+    /// dropped its sender).
+    SessionError {
+        /// Short machine-readable reason code (e.g. "subprocess_exited",
+        /// "transport_closed", "broadcast_dropped"). Stable across
+        /// versions for log filtering.
+        reason: String,
+        /// Human-readable message safe to show to the end user.
+        message: String,
+        /// ISO-8601 timestamp at which the error was detected.
+        received_at: chrono::DateTime<chrono::Utc>,
+    },
 }
 
 impl ChatEvent {
@@ -481,6 +505,7 @@ impl ChatEvent {
             ChatEvent::AutoContinueStateChanged { .. } => "auto_continue_state_changed",
             ChatEvent::Retrying { .. } => "retrying",
             ChatEvent::BackgroundOutput { .. } => "background_output",
+            ChatEvent::SessionError { .. } => "session_error",
         }
     }
 
@@ -592,6 +617,21 @@ impl ChatEvent {
                     source,
                     received_at.timestamp_millis(),
                     corr
+                ))
+            }
+
+            ChatEvent::SessionError {
+                reason,
+                received_at,
+                ..
+            } => {
+                // (reason, timestamp) — the same subprocess can only die
+                // once at a given instant; replays at distinct moments
+                // are distinct events.
+                Some(format!(
+                    "session_error:{}:{}",
+                    reason,
+                    received_at.timestamp_millis()
                 ))
             }
 
@@ -1409,6 +1449,17 @@ mod tests {
                 max_attempts: 3,
                 delay_ms: 1000,
                 error_message: "api_error: Internal server error".into(),
+            },
+            // T9 of plan 9a1684b2 — SessionError variant.
+            ChatEvent::SessionError {
+                reason: "subprocess_exited".into(),
+                message: "The CLI subprocess for this session has exited.".into(),
+                received_at: chrono::Utc::now(),
+            },
+            ChatEvent::SessionError {
+                reason: "transport_closed".into(),
+                message: "Lost connection to the CLI transport.".into(),
+                received_at: chrono::Utc::now(),
             },
         ];
 

--- a/src/chat/types.rs
+++ b/src/chat/types.rs
@@ -425,6 +425,30 @@ pub enum ChatEvent {
         /// The error message that triggered the retry
         error_message: String,
     },
+    /// **Out-of-band** event captured between turns by the permanent OOB
+    /// listener (see `chat::manager::spawn_oob_listener`).
+    ///
+    /// These are `Message`s that arrived on the SDK broadcast while no active
+    /// `stream_response` was running — typically background tool notifications
+    /// (Monitor output, BashOutput from `run_in_background`, sub-Agent
+    /// completion events, etc.).
+    ///
+    /// Frontends should render these distinctly from in-turn events (e.g. a
+    /// dedicated badge or icon on the message bubble). Persisted as
+    /// `background_output` and does NOT increment `message_count`.
+    BackgroundOutput {
+        /// Source descriptor — typically the tool name (e.g. "Monitor",
+        /// "BashOutput") or "system" for non-tool spontaneous messages.
+        source: String,
+        /// Human-readable content of the spontaneous message.
+        content: String,
+        /// ISO-8601 timestamp at which the OOB listener received the event.
+        received_at: chrono::DateTime<chrono::Utc>,
+        /// Optional correlation ID linking this event to a prior tool_use
+        /// (e.g. the background bash ID, the parent task ID).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        correlation_id: Option<String>,
+    },
 }
 
 impl ChatEvent {
@@ -456,6 +480,7 @@ impl ChatEvent {
             ChatEvent::AutoContinue { .. } => "auto_continue",
             ChatEvent::AutoContinueStateChanged { .. } => "auto_continue_state_changed",
             ChatEvent::Retrying { .. } => "retrying",
+            ChatEvent::BackgroundOutput { .. } => "background_output",
         }
     }
 
@@ -549,6 +574,26 @@ impl ChatEvent {
                 max_attempts,
                 ..
             } => Some(format!("retrying:{}:{}", attempt, max_attempts)),
+
+            ChatEvent::BackgroundOutput {
+                source,
+                received_at,
+                correlation_id,
+                ..
+            } => {
+                // (source, received_at, correlation_id) is enough to dedup OOB
+                // events: the same tool firing twice at the same instant with
+                // the same correlation is the same event. Content is excluded
+                // from the fingerprint so a retry that reformats whitespace
+                // does not duplicate the entry.
+                let corr = correlation_id.as_deref().unwrap_or("-");
+                Some(format!(
+                    "background_output:{}:{}:{}",
+                    source,
+                    received_at.timestamp_millis(),
+                    corr
+                ))
+            }
 
             // StreamDelta and StreamingStatus are never in the snapshot
             ChatEvent::StreamDelta { .. } | ChatEvent::StreamingStatus { .. } => None,
@@ -827,6 +872,13 @@ pub enum PendingMessageKind {
     /// System-generated hint (post-compaction context, guard hint, auto-continue)
     /// — persisted as `system_hint`, does NOT increment message_count
     SystemHint,
+    /// Out-of-band background event captured by the OOB listener while idle
+    /// (e.g. Monitor notification, BashOutput from `run_in_background`).
+    /// Persisted as `background_output`, does NOT increment message_count.
+    /// The OOB listener has ALREADY persisted+broadcasted the corresponding
+    /// `ChatEvent::BackgroundOutput` before pushing this entry — `stream_response`
+    /// must therefore NOT re-persist it (dedup via this kind).
+    BackgroundOutput,
 }
 
 /// A typed entry in the pending_messages queue.
@@ -857,6 +909,16 @@ impl PendingMessage {
     pub fn system_hint(content: String) -> Self {
         Self {
             kind: PendingMessageKind::SystemHint,
+            content,
+        }
+    }
+
+    /// Construct a `BackgroundOutput` pending entry. The OOB listener uses
+    /// this when an event arrives while the session is idle and a new
+    /// `stream_response` must be triggered to surface it to the LLM.
+    pub fn background_output(content: String) -> Self {
+        Self {
+            kind: PendingMessageKind::BackgroundOutput,
             content,
         }
     }
@@ -2426,5 +2488,63 @@ mod tests {
         log.record_tool_use("Write", &serde_json::json!({"content": "hello"}));
         assert!(log.files_modified.is_empty());
         assert_eq!(log.tool_use_count, 1);
+    }
+
+    #[test]
+    fn test_background_output_event_roundtrip() {
+        let received_at = chrono::DateTime::parse_from_rfc3339("2026-04-30T13:45:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let event = ChatEvent::BackgroundOutput {
+            source: "Monitor".into(),
+            content: "[epoch 50] cos=0.871".into(),
+            received_at,
+            correlation_id: Some("bg-abc123".into()),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"type\":\"background_output\""));
+        assert!(json.contains("\"source\":\"Monitor\""));
+        assert!(json.contains("\"correlation_id\":\"bg-abc123\""));
+
+        let parsed: ChatEvent = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ChatEvent::BackgroundOutput {
+                source,
+                content,
+                correlation_id,
+                ..
+            } => {
+                assert_eq!(source, "Monitor");
+                assert_eq!(content, "[epoch 50] cos=0.871");
+                assert_eq!(correlation_id.as_deref(), Some("bg-abc123"));
+            }
+            other => panic!("expected BackgroundOutput, got {:?}", other),
+        }
+
+        assert_eq!(event.event_type(), "background_output");
+        let fp = event.fingerprint().expect("BackgroundOutput must have a fingerprint");
+        assert!(fp.starts_with("background_output:Monitor:"));
+        assert!(fp.ends_with(":bg-abc123"));
+    }
+
+    #[test]
+    fn test_background_output_omits_correlation_id_when_none() {
+        let event = ChatEvent::BackgroundOutput {
+            source: "BashOutput".into(),
+            content: "build complete".into(),
+            received_at: chrono::Utc::now(),
+            correlation_id: None,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        // None correlation_id should be skipped, not serialized as null
+        assert!(!json.contains("correlation_id"));
+    }
+
+    #[test]
+    fn test_pending_message_background_output() {
+        let msg = PendingMessage::background_output("monitor: epoch 100".into());
+        assert_eq!(msg.kind, PendingMessageKind::BackgroundOutput);
+        assert_eq!(msg.content, "monitor: epoch 100");
     }
 }

--- a/src/chat/types.rs
+++ b/src/chat/types.rs
@@ -2574,7 +2574,9 @@ mod tests {
         }
 
         assert_eq!(event.event_type(), "background_output");
-        let fp = event.fingerprint().expect("BackgroundOutput must have a fingerprint");
+        let fp = event
+            .fingerprint()
+            .expect("BackgroundOutput must have a fingerprint");
         assert!(fp.starts_with("background_output:Monitor:"));
         assert!(fp.ends_with(":bg-abc123"));
     }

--- a/src/runner/guard.rs
+++ b/src/runner/guard.rs
@@ -15,7 +15,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 // ============================================================================
@@ -294,6 +294,35 @@ impl AgentGuard {
                                  Make your best judgment and proceed.",
                             )
                             .await;
+                        }
+
+                        // OOB events from background tools (Monitor, BashOutput,
+                        // sub-Agent completion, etc., emitted between turns by
+                        // the SDK and surfaced by `chat::oob_listener`).
+                        //
+                        // These prove the *session* is alive (the subprocess is
+                        // still running and producing) so we MUST reset the idle
+                        // timer — otherwise the guard would inject "are you
+                        // stuck?" hints in the middle of a long-running Monitor.
+                        //
+                        // We deliberately do NOT touch:
+                        //   - `tool_history` / `loop_threshold`: these track
+                        //     *agent* tool-use patterns. A Monitor in a noisy
+                        //     loop must not mask a real agent loop.
+                        //   - `completion_signals`: same reasoning — the agent's
+                        //     repeated "done" signals are independent of
+                        //     background activity.
+                        //
+                        // T7 of plan 9a1684b2 — "OOB events update last_activity
+                        // but NOT loop detection counters."
+                        ChatEvent::BackgroundOutput { source, .. } => {
+                            last_activity = Instant::now();
+                            idle_warned = false;
+                            debug!(
+                                session_id = %self.session_id,
+                                source = %source,
+                                "Guard: OOB event reset idle timer (loop detection unchanged)"
+                            );
                         }
 
                         _ => {}
@@ -1406,5 +1435,172 @@ mod tests {
         let config = crate::runner::models::RunnerConfig::default();
         assert_eq!(config.completion_loop_threshold, 5);
         assert_eq!(config.completion_max_chars, 200);
+    }
+
+    // ── T7: BackgroundOutput interaction with idle / loop detection ─────
+
+    /// Guard must NOT fire its idle hint while a background tool (Monitor,
+    /// BashOutput, etc.) is actively producing OOB events. The arrival of
+    /// any `BackgroundOutput` must reset `last_activity` even though no
+    /// agent tool_use happens.
+    #[tokio::test]
+    async fn test_guard_idle_silenced_by_background_output() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let hint_count = Arc::new(AtomicUsize::new(0));
+        let hint_count_clone = hint_count.clone();
+
+        struct MockHintSender {
+            count: Arc<AtomicUsize>,
+        }
+        #[async_trait::async_trait]
+        impl HintSender for MockHintSender {
+            async fn send_hint(&self, _session_id: &str, _message: &str) -> anyhow::Result<()> {
+                self.count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let (tx, rx) = broadcast::channel::<ChatEvent>(64);
+        let config = GuardConfig {
+            // Short idle timeout so the test runs quickly.
+            idle_timeout: Duration::from_millis(150),
+            task_timeout: Duration::from_millis(800),
+            check_interval: Duration::from_millis(40),
+            loop_threshold: 3,
+            ..Default::default()
+        };
+
+        let guard = AgentGuard::new(
+            "test-session".to_string(),
+            "Test Task".to_string(),
+            Uuid::new_v4(),
+            config,
+            rx,
+            Some(Arc::new(MockHintSender {
+                count: hint_count_clone,
+            })),
+            None,
+            None,
+        );
+
+        // Pump BackgroundOutput events at a fast cadence (every 50 ms,
+        // ~one third of idle_timeout) so `last_activity` is constantly
+        // bumped. End with a Result event to make the guard return
+        // Completed (drop(tx) wouldn't work — the test still holds `tx`).
+        let tx_clone = tx.clone();
+        tokio::spawn(async move {
+            for _ in 0..6 {
+                let _ = tx_clone.send(ChatEvent::BackgroundOutput {
+                    source: "Monitor".to_string(),
+                    content: "log line matched".to_string(),
+                    received_at: chrono::Utc::now(),
+                    correlation_id: None,
+                });
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            let _ = tx_clone.send(ChatEvent::Result {
+                session_id: "test".to_string(),
+                duration_ms: 300,
+                cost_usd: Some(0.0),
+                subtype: "success".to_string(),
+                is_error: false,
+                num_turns: Some(0),
+                result_text: None,
+            });
+        });
+
+        let verdict = guard.monitor().await;
+        assert!(matches!(verdict, GuardVerdict::Completed));
+        assert_eq!(
+            hint_count.load(Ordering::SeqCst),
+            0,
+            "OOB BackgroundOutput stream must keep the guard quiet — no idle hint expected"
+        );
+    }
+
+    /// Loop detection must remain sensitive to *agent* tool-use loops even
+    /// when interleaved with BackgroundOutput noise. A noisy Monitor
+    /// firing between repeated identical Read calls must NOT mask the
+    /// real loop.
+    #[tokio::test]
+    async fn test_guard_loop_detection_unaffected_by_background_output() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let hint_count = Arc::new(AtomicUsize::new(0));
+        let hint_count_clone = hint_count.clone();
+
+        struct MockHintSender {
+            count: Arc<AtomicUsize>,
+        }
+        #[async_trait::async_trait]
+        impl HintSender for MockHintSender {
+            async fn send_hint(&self, _session_id: &str, _message: &str) -> anyhow::Result<()> {
+                self.count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let (tx, rx) = broadcast::channel::<ChatEvent>(64);
+        let config = GuardConfig {
+            idle_timeout: Duration::from_secs(100),
+            task_timeout: Duration::from_secs(5),
+            loop_threshold: 3,
+            ..Default::default()
+        };
+
+        let guard = AgentGuard::new(
+            "test-session".to_string(),
+            "Test Task".to_string(),
+            Uuid::new_v4(),
+            config,
+            rx,
+            Some(Arc::new(MockHintSender {
+                count: hint_count_clone,
+            })),
+            None,
+            None,
+        );
+
+        // Interleave BackgroundOutput between identical ToolUse events.
+        // The OOB events must not reset tool_history.
+        let tx_clone = tx.clone();
+        tokio::spawn(async move {
+            for _ in 0..3 {
+                let _ = tx_clone.send(ChatEvent::ToolUse {
+                    id: "tu_loop".to_string(),
+                    tool: "Read".to_string(),
+                    input: serde_json::json!({"path": "/same/file.rs"}),
+                    parent_tool_use_id: None,
+                });
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                // OOB noise between agent tool calls — MUST NOT reset
+                // tool_history or the loop will go undetected.
+                let _ = tx_clone.send(ChatEvent::BackgroundOutput {
+                    source: "BashOutput".to_string(),
+                    content: "bg noise".to_string(),
+                    received_at: chrono::Utc::now(),
+                    correlation_id: None,
+                });
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = tx_clone.send(ChatEvent::Result {
+                session_id: "test".to_string(),
+                duration_ms: 1000,
+                cost_usd: Some(0.01),
+                subtype: "success".to_string(),
+                is_error: false,
+                num_turns: Some(3),
+                result_text: None,
+            });
+        });
+
+        let verdict = guard.monitor().await;
+        assert!(matches!(verdict, GuardVerdict::Completed));
+        assert!(
+            hint_count.load(Ordering::SeqCst) >= 1,
+            "Loop detection must still fire despite BackgroundOutput interleaving"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes the architectural hole identified in plan `9a1684b2`: between two `stream_response` invocations on a chat session, **no tokio task was reading the Claude Code subprocess** driven by `nexus_claude::InteractiveClient`. As a result, every spontaneous SDK event (Monitor matches, BashOutput from `run_in_background`, sub-Agent completion events, AskUserQuestion fired between turns, hooks, PreCompact, deferred PermissionRequest…) was buffered in the SDK pipe and only delivered the next time the user typed something — making the session appear "frozen" while the agent insisted it was "monitoring".

This PR wires a **permanent OOB listener task per session** that consumes the SDK broadcast continuously, surfaces events as a typed `ChatEvent::BackgroundOutput`, persists them, and (optionally) re-spawns `stream_response` so the LLM reacts autonomously between user turns — gated by a sliding-window rate cap so a misbehaving Monitor cannot loop the session.

Depends on `this-rs/nexus#29` (merged as `fc00740`) which adds `Transport::subscribe_messages` + `InteractiveClient::subscribe_messages`.

## Architecture

```
Monitor stdout (or BashOutput, sub-Agent, hook, …)
  → nexus SubprocessTransport broadcast::Sender<Message>
  → subscribe_messages() stream
  → chat::oob_listener::spawn_oob_listener  (permanent tokio task per session)
  → handle_oob_message
      ├─ persist as ChatEventRecord (background_output type)
      ├─ broadcast ChatEvent::BackgroundOutput on events_tx (+ NATS)
      └─ maybe_trigger_stream
          ├─ rate-cap check (50/5min interactive, 5/5min runner)
          ├─ push PendingMessage::BackgroundOutput
          ├─ compare_exchange(false → true) on is_streaming
          └─ if won race: tokio::spawn(stream_response) with content as prompt
```

## Tasks completed (plan 9a1684b2)

| # | Task | Commit |
|---|---|---|
| T1 | Audit nexus_claude SDK surface | (audit only) |
| T2 | Patch nexus to expose OOB receiver | this-rs/nexus#29 + `b36ff00` (local patch during dev) + `6bc2dbb` (drop patch) |
| T6 | `ChatEvent::BackgroundOutput` + `PendingMessageKind` variant | `45d7c5e` |
| T3 | Spawn permanent OOB listener task in `create_session`/`resume_session` | `bb4ffa3` |
| T4 | Trigger `stream_response` on idle OOB events (compare_exchange) | `afa3683` |
| T7 | Auto-continue cap + AgentGuard awareness | `bb7d920` |
| T9 | `ChatEvent::SessionError` + structured tracing for observability | `d56ac63` |
| T8 | End-to-end tests via `MockTransport` | `68ef655` |
| — | Bump nexus rev after merge | `6bc2dbb` |

## Key files touched

- **New**: `src/chat/oob_listener.rs` — listener spawn + message handling + cap helper + subprocess-death emission + 11 unit tests (incl. 2 E2E via MockTransport, 3 cap tests, 1 SessionError test)
- `src/chat/manager.rs` — wires `spawn_oob_listener` from `create_session` and `resume_session` with all required `OobListenerDeps`; adds 4 OOB-related fields on `ActiveSession` (`oob_trigger_history`, `oob_trigger_cap`, `oob_trigger_window`, `oob_capped_warned`)
- `src/chat/types.rs` — adds `ChatEvent::BackgroundOutput { source, content, received_at, correlation_id }` and `ChatEvent::SessionError { reason, message, received_at }` (both backward-compatible — appended at the end of the enum)
- `src/chat/drain.rs` — teaches `drain_pending_messages` about `BackgroundOutput`: skips re-persist + re-broadcast (the listener already did both) and forwards content as prompt only
- `src/runner/guard.rs` — `BackgroundOutput` arm in `monitor()`: resets `last_activity` (no idle hint while OOB activity is happening) but **deliberately leaves** `tool_history` and `completion_signals` untouched (a noisy Monitor must not mask a real agent loop)
- `src/chat/post_stream.rs` — initialise the new ActiveSession fields in the test helper

## Knowledge captured

- **Note (gotcha)** — historical buffering bug context for future regression risk
- **Note (pattern)** — listener-permanent-par-session with shared cancellation token (reusable for future NATS / file-watcher / other broadcast-driven tasks)
- **Note (guideline)** — pitfalls to respect when modifying OOB / AgentGuard (cap is mandatory, last_activity ≠ loop_detection counters, runner/interactive cap asymmetry, SessionError vs SystemHint)
- **Note (gotcha)** — anti-pattern `const _: T = ...` "false suppression" that creates compile errors instead of suppressing warnings
- **Decision** — no separate `respawn_oob_listener` API needed: recovery reuses `create_session`/`resume_session` lifecycle which already spawn the listener
- **Plan stub** — `d6a6a20d` on `project-orchestrator-frontend` for the WebSocket consumer side (badge for `BackgroundOutput`, banner for `SessionError`)

## Test plan

- [x] `cargo test --lib chat::oob_listener` → 11/11 pass (5 unit + 3 cap + 1 SessionError + 2 E2E via MockTransport)
- [x] `cargo test --lib runner::guard` → 22/22 pass (2 new BackgroundOutput-aware tests)
- [x] `cargo test --lib chat::types` → 64/64 pass (SessionError serde round-trip)
- [x] `cargo test --lib` → 5736 pass / 0 fail (1 unrelated flaky timing test in `events::reactions` that passes in isolation)
- [x] **Live test on the dev session itself** — set up a real `Monitor` with 3 events spaced 3s, all 3 events delivered between turns as expected, complete event arrived batched with the 3rd
- [x] Sanity rebuild after dropping the local `[patch]` and pointing back at upstream `fc00740` — full build succeeds, OOB tests still pass

## Backward compatibility

- New `ChatEvent` variants appended at the end → existing serde round-trip preserved
- `Transport::subscribe_messages` returns `None` by default → consumers that wire up the listener with a transport that doesn't override it (e.g. very old MockTransport) get a warning log + the listener exits gracefully, leaving the session functional
- All existing `ActiveSession` literal sites updated with the new OOB fields (5 sites: 2 in production paths, 3 in test helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)