### PR TITLE
fix(chat): prevent user-message starvation in pending_messages drain

### DIFF
--- a/src/chat/drain.rs
+++ b/src/chat/drain.rs
@@ -320,7 +320,8 @@ mod tests {
             PendingMessageKind::User,
             "BUG: User message starved by accumulated BackgroundOutput. \
              pop_highest_priority returned {:?} content={:?}",
-            first.kind, first.content
+            first.kind,
+            first.content
         );
         assert_eq!(first.content, "U1");
 
@@ -448,7 +449,10 @@ mod tests {
         let mut q = VecDeque::new();
         q.push_back(bg("only"));
         assert_next(&mut q, PendingMessageKind::BackgroundOutput, "only");
-        assert!(q.is_empty(), "queue must be empty after popping the sole entry");
+        assert!(
+            q.is_empty(),
+            "queue must be empty after popping the sole entry"
+        );
         assert!(pop_highest_priority(&mut q).is_none());
     }
 

--- a/src/chat/drain.rs
+++ b/src/chat/drain.rs
@@ -274,12 +274,27 @@ mod tests {
     fn user(content: &str) -> PendingMessage {
         PendingMessage::user(content.to_string())
     }
-    #[allow(dead_code)] // used by tests added in T3 of plan 806c8f2c
     fn system_hint(content: &str) -> PendingMessage {
         PendingMessage::system_hint(content.to_string())
     }
     fn bg(content: &str) -> PendingMessage {
         PendingMessage::background_output(content.to_string())
+    }
+
+    /// Helper: assert next pop is `expected_kind` with `expected_content`.
+    #[track_caller]
+    fn assert_next(
+        q: &mut VecDeque<PendingMessage>,
+        expected_kind: PendingMessageKind,
+        expected_content: &str,
+    ) {
+        let m = pop_highest_priority(q).expect("queue not empty");
+        assert_eq!(
+            m.kind, expected_kind,
+            "wrong kind: got {:?} content={:?}, expected {:?} content={:?}",
+            m.kind, m.content, expected_kind, expected_content
+        );
+        assert_eq!(m.content, expected_content);
     }
 
     /// **T1 of plan 806c8f2c — RED test that demonstrates the bug.**
@@ -318,6 +333,158 @@ mod tests {
                 "FIFO intra-class violated: expected {expected}"
             );
         }
+
+        assert!(pop_highest_priority(&mut q).is_none());
+    }
+
+    // ========================================================================
+    // T3 of plan 806c8f2c — Comprehensive priority + FIFO invariants.
+    //
+    // The 9 tests below cover the full truth table of `pop_highest_priority`:
+    //   - Single-priority comparisons (User > BG, User > SystemHint, SH > BG)
+    //   - FIFO intra-class for User and BackgroundOutput (the two dominant
+    //     classes in production)
+    //   - Edge cases: empty queue, single entry
+    //   - The full mixed scenario [BG, U, SH, BG, U, SH, BG] which is the
+    //     most valuable single test — exercises priority + FIFO together.
+    // ========================================================================
+
+    #[test]
+    fn test_priority_user_beats_background() {
+        let mut q = VecDeque::new();
+        q.push_back(bg("BG"));
+        q.push_back(user("U"));
+        assert_next(&mut q, PendingMessageKind::User, "U");
+        assert_next(&mut q, PendingMessageKind::BackgroundOutput, "BG");
+        assert!(pop_highest_priority(&mut q).is_none());
+    }
+
+    #[test]
+    fn test_priority_user_beats_systemhint() {
+        let mut q = VecDeque::new();
+        q.push_back(system_hint("SH"));
+        q.push_back(user("U"));
+        assert_next(&mut q, PendingMessageKind::User, "U");
+        assert_next(&mut q, PendingMessageKind::SystemHint, "SH");
+        assert!(pop_highest_priority(&mut q).is_none());
+    }
+
+    #[test]
+    fn test_priority_systemhint_beats_background() {
+        let mut q = VecDeque::new();
+        q.push_back(bg("BG"));
+        q.push_back(system_hint("SH"));
+        assert_next(&mut q, PendingMessageKind::SystemHint, "SH");
+        assert_next(&mut q, PendingMessageKind::BackgroundOutput, "BG");
+        assert!(pop_highest_priority(&mut q).is_none());
+    }
+
+    #[test]
+    fn test_priority_user_beats_multiple_backgrounds() {
+        // The User entry is in the MIDDLE of a sea of BGs — it must still
+        // win, then the remaining BGs come out in their original FIFO order
+        // (BG1, BG2, BG3, BG4 — note BG4 was inserted AFTER U so it stays
+        // last even though U was extracted before it).
+        let mut q = VecDeque::new();
+        q.push_back(bg("BG1"));
+        q.push_back(bg("BG2"));
+        q.push_back(bg("BG3"));
+        q.push_back(user("U"));
+        q.push_back(bg("BG4"));
+
+        assert_next(&mut q, PendingMessageKind::User, "U");
+        for expected in ["BG1", "BG2", "BG3", "BG4"] {
+            let next = pop_highest_priority(&mut q).expect("queue not empty");
+            assert_eq!(next.kind, PendingMessageKind::BackgroundOutput);
+            assert_eq!(
+                next.content, expected,
+                "FIFO intra-class violated: expected {expected}"
+            );
+        }
+        assert!(pop_highest_priority(&mut q).is_none());
+    }
+
+    #[test]
+    fn test_priority_fifo_within_user_class() {
+        // Three User messages in a row — strict insertion order out.
+        // Catches the `min_by_key` trap (returns LAST on equal keys).
+        let mut q = VecDeque::new();
+        q.push_back(user("U1"));
+        q.push_back(user("U2"));
+        q.push_back(user("U3"));
+        assert_next(&mut q, PendingMessageKind::User, "U1");
+        assert_next(&mut q, PendingMessageKind::User, "U2");
+        assert_next(&mut q, PendingMessageKind::User, "U3");
+        assert!(pop_highest_priority(&mut q).is_none());
+    }
+
+    #[test]
+    fn test_priority_fifo_within_background_class() {
+        // Three BackgroundOutput in a row — strict insertion order out.
+        // This is the "Monitor tick" case: agents must see ticks in the
+        // order they were produced, otherwise the assistant gets confused
+        // ("Tick 5" arriving before "Tick 4" makes no narrative sense).
+        let mut q = VecDeque::new();
+        q.push_back(bg("BG1"));
+        q.push_back(bg("BG2"));
+        q.push_back(bg("BG3"));
+        assert_next(&mut q, PendingMessageKind::BackgroundOutput, "BG1");
+        assert_next(&mut q, PendingMessageKind::BackgroundOutput, "BG2");
+        assert_next(&mut q, PendingMessageKind::BackgroundOutput, "BG3");
+        assert!(pop_highest_priority(&mut q).is_none());
+    }
+
+    #[test]
+    fn test_priority_empty_queue() {
+        let mut q: VecDeque<PendingMessage> = VecDeque::new();
+        assert!(
+            pop_highest_priority(&mut q).is_none(),
+            "empty queue must return None, not panic"
+        );
+    }
+
+    #[test]
+    fn test_priority_single_entry() {
+        let mut q = VecDeque::new();
+        q.push_back(bg("only"));
+        assert_next(&mut q, PendingMessageKind::BackgroundOutput, "only");
+        assert!(q.is_empty(), "queue must be empty after popping the sole entry");
+        assert!(pop_highest_priority(&mut q).is_none());
+    }
+
+    /// The most valuable single test of the suite. Mixes 3 priority classes
+    /// across 7 entries and asserts the full pop sequence:
+    ///
+    ///   queue (insertion order): BG1, U1, SH1, BG2, U2, SH2, BG3
+    ///   expected pop sequence:   U1, U2, SH1, SH2, BG1, BG2, BG3
+    ///
+    /// This single test would catch:
+    ///   - Any priority inversion (User not first)
+    ///   - Any FIFO-intra-class violation (U2 before U1, or SH2 before SH1)
+    ///   - The `min_by_key` trap (LAST on equal keys)
+    ///   - Off-by-one in the index tie-break
+    ///   - Failure to remove from the right index after `enumerate()`
+    #[test]
+    fn test_priority_mixed_complex() {
+        let mut q = VecDeque::new();
+        q.push_back(bg("BG1"));
+        q.push_back(user("U1"));
+        q.push_back(system_hint("SH1"));
+        q.push_back(bg("BG2"));
+        q.push_back(user("U2"));
+        q.push_back(system_hint("SH2"));
+        q.push_back(bg("BG3"));
+
+        // Users first, in FIFO order.
+        assert_next(&mut q, PendingMessageKind::User, "U1");
+        assert_next(&mut q, PendingMessageKind::User, "U2");
+        // Then SystemHints, in FIFO order.
+        assert_next(&mut q, PendingMessageKind::SystemHint, "SH1");
+        assert_next(&mut q, PendingMessageKind::SystemHint, "SH2");
+        // Then BackgroundOutputs, in FIFO order.
+        assert_next(&mut q, PendingMessageKind::BackgroundOutput, "BG1");
+        assert_next(&mut q, PendingMessageKind::BackgroundOutput, "BG2");
+        assert_next(&mut q, PendingMessageKind::BackgroundOutput, "BG3");
 
         assert!(pop_highest_priority(&mut q).is_none());
     }

--- a/src/chat/drain.rs
+++ b/src/chat/drain.rs
@@ -205,3 +205,91 @@ pub(crate) async fn drain_pending_messages(
         );
     }
 }
+
+/// Pop the highest-priority `PendingMessage` from the queue, preserving
+/// FIFO order within a single priority class.
+///
+/// Priority order (lowest number = highest priority):
+///   0 — `User` : the human's intent always wins
+///   1 — `SystemHint` : system instructions (AgentGuard hints, plan-runner reminders)
+///   2 — `BackgroundOutput` : passive observations from background tools (Monitor, BashOutput, …)
+///
+/// ## Why this exists (plan 806c8f2c)
+///
+/// Without prioritisation, a noisy `Monitor` (or any background-output-emitting
+/// tool) can starve user messages: BackgroundOutput entries accumulate in
+/// `pending_messages` while a stream is running, and a strict FIFO drain
+/// processes them all before reading the user's typed message — the user
+/// perceives the chat as "ignoring me" while ticks keep firing.
+///
+/// ## Complexity
+///
+/// `O(n)` scan over the queue + `O(n)` `remove(idx)`. `n` is typically < 50;
+/// in practice the queue rarely exceeds 5-10 entries between drain cycles.
+///
+/// ## STUB (T1 of plan 806c8f2c)
+///
+/// This stub currently delegates to `pop_front()` — strict FIFO, buggy.
+/// The tests below will FAIL on this stub, demonstrating the bug. T2 of
+/// the same plan replaces the body with the real priority-aware impl.
+fn pop_highest_priority(queue: &mut VecDeque<PendingMessage>) -> Option<PendingMessage> {
+    // STUB — see doc-comment.
+    queue.pop_front()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chat::types::PendingMessage;
+
+    fn user(content: &str) -> PendingMessage {
+        PendingMessage::user(content.to_string())
+    }
+    #[allow(dead_code)] // used by tests added in T3 of plan 806c8f2c
+    fn system_hint(content: &str) -> PendingMessage {
+        PendingMessage::system_hint(content.to_string())
+    }
+    fn bg(content: &str) -> PendingMessage {
+        PendingMessage::background_output(content.to_string())
+    }
+
+    /// **T1 of plan 806c8f2c — RED test that demonstrates the bug.**
+    ///
+    /// On main HEAD with `pop_highest_priority` stubbed to `pop_front`, this
+    /// test FAILS: the 3 BackgroundOutput entries are popped before the
+    /// User message, reproducing the starvation symptom observed in prod.
+    ///
+    /// After T2 replaces the stub with the real priority-aware impl, this
+    /// test PASSES — and serves as a permanent non-regression guard.
+    #[test]
+    fn test_user_message_drained_before_accumulated_background_outputs() {
+        let mut q = VecDeque::new();
+        q.push_back(bg("BG1"));
+        q.push_back(bg("BG2"));
+        q.push_back(bg("BG3"));
+        q.push_back(user("U1"));
+
+        // Expected behavior: User wins, then BG1 BG2 BG3 in FIFO order.
+        let first = pop_highest_priority(&mut q).expect("queue not empty");
+        assert_eq!(
+            first.kind,
+            PendingMessageKind::User,
+            "BUG: User message starved by accumulated BackgroundOutput. \
+             pop_highest_priority returned {:?} content={:?}",
+            first.kind, first.content
+        );
+        assert_eq!(first.content, "U1");
+
+        // FIFO within BackgroundOutput class is preserved.
+        for expected in ["BG1", "BG2", "BG3"] {
+            let next = pop_highest_priority(&mut q).expect("queue not empty");
+            assert_eq!(next.kind, PendingMessageKind::BackgroundOutput);
+            assert_eq!(
+                next.content, expected,
+                "FIFO intra-class violated: expected {expected}"
+            );
+        }
+
+        assert!(pop_highest_priority(&mut q).is_none());
+    }
+}

--- a/src/chat/drain.rs
+++ b/src/chat/drain.rs
@@ -52,10 +52,12 @@ pub(crate) async fn drain_pending_messages(
     enrichment_pipeline: Arc<super::enrichment::EnrichmentPipeline>,
     search: Arc<dyn SearchStore>,
 ) {
-    // Pop the next message from the queue
+    // Pop the next message from the queue, prioritising User > SystemHint
+    // > BackgroundOutput so a noisy Monitor cannot starve user messages
+    // (plan 806c8f2c, T2). FIFO is preserved within each priority class.
     let next_message = {
         let mut queue = pending_messages.lock().await;
-        queue.pop_front()
+        pop_highest_priority(&mut queue)
     };
 
     if let Some(next_msg) = next_message {
@@ -227,14 +229,41 @@ pub(crate) async fn drain_pending_messages(
 /// `O(n)` scan over the queue + `O(n)` `remove(idx)`. `n` is typically < 50;
 /// in practice the queue rarely exceeds 5-10 entries between drain cycles.
 ///
-/// ## STUB (T1 of plan 806c8f2c)
+/// ## Implementation
 ///
-/// This stub currently delegates to `pop_front()` — strict FIFO, buggy.
-/// The tests below will FAIL on this stub, demonstrating the bug. T2 of
-/// the same plan replaces the body with the real priority-aware impl.
+/// Scan the queue once, track the index of the first entry of the lowest
+/// priority value seen so far (lower number = higher priority). Then
+/// `remove(idx)` it. Both ops are O(n) on `VecDeque`; n is small enough
+/// that this is fine.
+///
+/// ## FIFO tie-break
+///
+/// Within a single priority class, the iteration finds the first match
+/// (oldest in the queue), so insertion order is preserved among equals.
 fn pop_highest_priority(queue: &mut VecDeque<PendingMessage>) -> Option<PendingMessage> {
-    // STUB — see doc-comment.
-    queue.pop_front()
+    fn priority(kind: &PendingMessageKind) -> u8 {
+        match kind {
+            PendingMessageKind::User => 0,
+            PendingMessageKind::SystemHint => 1,
+            PendingMessageKind::BackgroundOutput => 2,
+        }
+    }
+
+    // NB: must use `min_by` with explicit tie-break on the index, because
+    // `min_by_key` returns the LAST element on equal keys (cf std docs) —
+    // which would break our FIFO-intra-class invariant. Index is unique so
+    // the secondary `cmp` always disambiguates.
+    let best_idx = queue
+        .iter()
+        .enumerate()
+        .min_by(|(ia, a), (ib, b)| {
+            priority(&a.kind)
+                .cmp(&priority(&b.kind))
+                .then_with(|| ia.cmp(ib))
+        })
+        .map(|(i, _)| i)?;
+
+    queue.remove(best_idx)
 }
 
 #[cfg(test)]

--- a/src/chat/oob_listener.rs
+++ b/src/chat/oob_listener.rs
@@ -374,23 +374,31 @@ async fn maybe_trigger_stream(
         return;
     }
 
-    // Push the OOB content as a queue entry so drain_pending_messages
-    // (or the spawned stream_response below) can process it later.
-    {
-        let mut queue = pending_messages.lock().await;
-        queue.push_back(PendingMessage::background_output(oob_content.clone()));
-    }
-
-    // Claim the streaming flag atomically. Loser leaves the message in
-    // the queue — drain will pick it up after the active turn ends.
+    // T6 of plan 806c8f2c — Claim FIRST, push only on lost race.
+    //
+    // The previous logic was push-then-pop (push BG to queue, then if won
+    // race pop_front the queue to use as prompt). That was brittle: if
+    // *another* entry landed in the queue between our push and our pop
+    // (possible during the `finalize_streaming_status` window where
+    // is_streaming flips false but the queue is briefly inspected without
+    // a continuous lock), pop_front would return THAT entry — potentially
+    // a User message that should have gone through drain's
+    // priority-aware path. The bug was latent rather than active because
+    // the timing window is narrow, but eliminating the primitive removes
+    // the risk entirely. Cf companion fix in drain.rs (T2).
     let won_race = is_streaming
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_ok();
 
     if !won_race {
+        // Lost — leave the OOB content in the queue. drain_pending_messages
+        // will pick it up after the active turn ends, prioritised below
+        // any User/SystemHint that's also queued (cf drain.rs::pop_highest_priority).
+        let mut queue = pending_messages.lock().await;
+        queue.push_back(PendingMessage::background_output(oob_content));
         debug!(
             session_id = %session_id,
-            "OOB listener: lost is_streaming race — message queued for active stream's drain"
+            "OOB listener: lost is_streaming race — queued for drain"
         );
         return;
     }
@@ -404,18 +412,14 @@ async fn maybe_trigger_stream(
         session_id = %session_id,
         oob_trigger_count = trigger_count,
         oob_trigger_cap = oob_trigger_cap,
-        "OOB listener: idle session, spawning stream_response for queued OOB event"
+        "OOB listener: idle session, spawning stream_response for OOB event"
     );
 
-    // Pop the entry we just pushed (drain will see it via the queue).
-    // Actually we WANT drain to handle it — but stream_response needs an
-    // initial prompt. Give it the OOB content directly; the queue
-    // remains for any subsequent OOB events that may have stacked up
-    // between the push and the spawn.
-    let prompt = {
-        let mut queue = pending_messages.lock().await;
-        queue.pop_front().map(|m| m.content).unwrap_or(oob_content)
-    };
+    // Won the race — use the OOB content directly. The queue stays
+    // untouched; any subsequent OOB events that arrive between this
+    // point and the spawn (or during the spawn) push themselves to the
+    // queue via the lost-race branch above and drain handles them after.
+    let prompt = oob_content;
 
     // Spawn stream_response. Same call shape as in `spawn_nats_rpc_listener`.
     let session_id_for_spawn = session_id.to_string();


### PR DESCRIPTION
## Summary

- Fixes a starvation bug where a noisy `Monitor` (or any background-output-emitting tool) could indefinitely delay user messages: `drain_pending_messages` used `pop_front()` which is strict FIFO, so accumulated `BackgroundOutput` entries were processed before queued `User` messages.
- Replace the strict FIFO pop with `pop_highest_priority`, prioritising `User > SystemHint > BackgroundOutput`. FIFO is preserved within each priority class to keep tick ordering coherent ("Tick 5" never lands before "Tick 4").
- Defensive companion: refactor `chat::oob_listener::maybe_trigger_stream` from push-then-pop to claim-first, eliminating a latent race where `pop_front()` could return the wrong entry between the push and the claim.

## Why this matters

Reported in production: with a 60s-tick `Monitor` and 5-30s LLM responses, the `pending_messages` queue could accumulate several `BackgroundOutput` entries before the user's `STOP` message was even seen. The user observation was *"il dit attendre et être notifier mais en réalité il coupe et ne me laisse pas le relancer"*.

## Scope

| File | Change |
|------|--------|
| `src/chat/drain.rs` | Replace `queue.pop_front()` with `pop_highest_priority(&mut queue)`. Add the helper + 9 unit tests covering the full priority × FIFO truth table. |
| `src/chat/oob_listener.rs` | Already on this branch via `7c15f74`: claim-first refactor. The single remaining `pop_front` is on the rate-cap sliding window history (legitimate). |

## Implementation notes

- **`min_by` not `min_by_key`**: `min_by_key` returns the *last* element on equal keys per the std docs, which would silently break our FIFO-intra-class invariant. We use `min_by` with explicit `then_with(|ia, ib| ia.cmp(ib))` on the index.
- **Cost**: `O(n)` scan + `O(n)` `remove(idx)` on `VecDeque`. Acceptable as long as `n` stays small (we observe ≤ 10 entries between drain cycles).

## Test plan

- [x] Unit test `test_user_message_drained_before_accumulated_background_outputs` — RED on `main`, GREEN with the fix (commit `127f142` introduced the failing test as a regression guard).
- [x] 9 additional unit tests (commit `07824ab`) covering the full priority × FIFO truth table including the mixed scenario `[BG,U,SH,BG,U,SH,BG] → U,U,SH,SH,BG,BG,BG`.
- [x] `cargo test --lib chat::drain` → 10/10 pass.
- [x] `cargo test --lib chat::oob_listener` → 11/11 pass.
- [x] `cargo clippy --lib --tests -- -D warnings` → clean.
- [x] `cargo fmt --all --check` → clean.
- [x] Live test on a running PO instance (plan `806c8f2c` task `3737470e`):
  - **Phase A** — 5 events fired into `/tmp/test_starvation.log` during a streaming turn, all queued correctly under `is_streaming=true` (lost race), drained in strict FIFO order after the turn ended.
  - **Phase B** — User message typed mid-turn was delivered ahead of any queued backlog and answered within a single LLM cycle. Documented in note `60d6fb4b`.

## Linked artefacts

- Plan: [`806c8f2c` Fix user-message starvation in pending_messages drain](http://localhost:3000/workspace/project-orchestrator/plans/806c8f2c-422c-4905-b5d5-c096f09781ce)
- Knowledge notes:
  - Pattern `542f923f` — *Priority drain for mixed-source queues*
  - Guideline `9acf3403` (importance: critical) — *Background-output MUST NEVER starve user messages*
  - Gotcha `5cb345f5` — *OOB ticks accumulate in pending_messages while is_streaming=true*
  - Observation `60d6fb4b` — *Live test of OOB → drain pipeline*

## Commit history

| SHA | Subject |
|-----|---------|
| `127f142` | test(chat): RED test reproducing user-message starvation in drain (T1) |
| `c3b3b3e` | fix(chat): implement pop_highest_priority to prevent user-message starvation (T2) |
| `7c15f74` | refactor(chat): claim-first in OOB listener, eliminate push-then-pop (T6) |
| `07824ab` | test(chat): comprehensive priority + FIFO invariants for drain (T3) |
| `ace3be3` | style: cargo fmt on chat::drain tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)