### PR TITLE
fix(chat): spawn background-tasks poller in resume_session

### DIFF
--- a/src/chat/manager.rs
+++ b/src/chat/manager.rs
@@ -5491,6 +5491,22 @@ impl ChatManager {
             nats_cancel.clone(),
         );
 
+        // Spawn the per-session background-tasks poller (T12 of plan
+        // 754a1379). Mirror of `create_session` — without this spawn,
+        // resumed sessions never run the grace-period purge, so
+        // `pending_removal_at` set by `cancel_task` is never honoured
+        // and entries linger forever in `active_background_tasks`.
+        // (Bug discovered post-V2 cancel_task: a stuck "stopping…"
+        // entry in the frontend with PIDs already dead — the poller
+        // wasn't running for resumed sessions to physically purge.)
+        Self::spawn_background_tasks_poller(
+            session_id.to_string(),
+            self.active_sessions.clone(),
+            events_tx.clone(),
+            self.nats.clone(),
+            nats_cancel.clone(),
+        );
+
         // Spawn the permanent out-of-band SDK message listener (T4+T5 of
         // plan 9a1684b2). Same as `create_session` — the resumed session
         // needs its own listener bound to the new InteractiveClient. The


### PR DESCRIPTION
## Summary

**Root cause** of the post-#242 bug where users see Monitor / Bash bg entries stuck in "stopping…" indefinitely after clicking Stop, with the entries reappearing as "active" on frontend reload.

`spawn_background_tasks_poller` was only wired into `create_session`. Sessions loaded via `resume_session` (typical case after a server restart, or after navigating back to a previously created chat) **never got the poller**. Without it:

- `cancel_task` correctly marks `pending_removal_at = Some(now)` ✅
- `kill_subtree` correctly SIGINTs the subtree (V2 path) ✅
- BUT phase 2 of `tick_purge_background_tasks` never runs ❌
- → entry lingers in `active_background_tasks` forever
- → REST snapshot (`GET /api/chat/sessions/:id/background-tasks`) keeps returning it
- → frontend on reload re-displays the entry as active

## Live evidence

Reproduced verbatim on the running PO server during diagnosis:

- Session `03c8cc41` (created the prior day, resumed at server start today)
- 3 tracked entries, all with `pid: Some(...)` populated by V2 async claim:
  - `Re-watch backend PR #242` — pid 6510 — **already dead** (`gh pr checks --watch` exited at CI completion)
  - `Watch backend PR #242 CI checks` — pid 96575 — **already dead**
  - `PID claim diagnostic` — pid 13630 — killed by my own `cancel_task` test (returned `killed_pids: [13630, 13632]`, `pgrep -f "tail.*po-monitor-diag"` confirmed empty post-cancel)
- All 3 entries persisted in the map past the grace period; user reported them stuck "stopping…" for 35m+ in the frontend

`pgrep` confirmed the PIDs were dead. `GET /background-tasks` confirmed the entries were still in the map. The poller wasn't running.

## Fix

One spawn call added to `resume_session`, mirroring the placement in `create_session` (between the cancel-tools listener and the OOB listener):

```rust
Self::spawn_background_tasks_poller(
    session_id.to_string(),
    self.active_sessions.clone(),
    events_tx.clone(),
    self.nats.clone(),
    nats_cancel.clone(),
);
```

Bound to `nats_cancel` so it terminates cleanly on session replacement / teardown.

## Why no new test

The poller's purge logic is already exhaustively unit-tested by `test_tick_purge_*` (grace expiry, idle-death detection, broadcast on mutation, no-op on quiet tick). All those tests would have continued passing through the entire window where this bug existed in production, because they call the poller directly without going through `resume_session`.

The missing wire-up is best caught at the integration-test level. The existing `tests/cancel_task_e2e.rs` manual-scenario stubs already document multi-session resume coverage as future work (gated on the test-server fixture, decision `8336f2f3`).

## Manual repro after fix

1. Start PO with this branch.
2. Have a session with stale `bash_background` / `monitor` entries (subprocesses already exited).
3. Resume the session by reloading the frontend.
4. Click Stop on a stale entry → `pending_removal_at` set.
5. Within 5–10 s the entry physically purges from the map.
6. Frontend `cancellingIds` drops; the row disappears; "stopping…" goes away.
7. Subsequent `GET /background-tasks` returns the smaller list.

## Test plan

- [ ] Restart PO with this branch.
- [ ] Verify a previously-stuck session has its entries purged within 5–10 s of clicking Stop (or, for entries with stale `last_seen_at` >30 min, purged automatically by phase 1 + phase 2).
- [ ] Verify on frontend reload, purged entries do **not** reappear.
- [ ] Run unit tests: `cargo test --lib chat::manager::tests` → 213/213.

## History

- Plan #242 (V2 cancel_task) merged earlier today — added the kill chain.
- This PR fixes a pre-existing gap from plan 754a1379 (T12) that V2 inherited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)