### PR TITLE
chore(deps): bump openssl 0.10.76 → 0.10.78 (closes 5 alerts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5243,9 +5243,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -5290,9 +5290,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary

Patch security release for `openssl`, closing 5 Dependabot alerts on root `Cargo.lock`. Fixes several soundness issues where safe Rust callers could trigger out-of-bounds reads or writes.

| GHSA | Sev | Issue |
|---|---|---|
| GHSA-pqf5-4pqq-29f5 | high | `Deriver::derive` overflow short buffers |
| GHSA-8c75-8mhr-p7r9 | high | Incorrect bounds in AES key wrap |
| GHSA-hppc-g8h3-xhp3 | high | Unchecked callback length PSK/cookie |
| GHSA-ghm9-cr32-g9qj | high | `digest_final` writes past caller buffer |
| GHSA-xmgf-hq76-4vx2 | low | OOB read in PEM password callback |

## Why this is safe

Per the [openssl 0.10.78 changelog](https://github.com/sfackler/rust-openssl/blob/master/openssl/CHANGELOG.md), this is a **pure security fix release** with no breaking changes. Patch bump (0.10.76 → 0.10.78) within the 0.10.x line. Also adds support for OpenSSL 4.x and LibreSSL 4.3.x.

We don't use `openssl` directly anywhere in the codebase. It's a transitive dep via `fastembed → ort → ureq → native-tls → openssl`. This is a **lockfile-only bump** — no `Cargo.toml` modification.

## Verification

- `cargo update -p openssl --precise 0.10.78` succeeds
- `Cargo.lock` confirms `openssl 0.10.78` (and `openssl-sys 0.9.114`)
- `cargo check --lib` clean
- `cargo test --lib chat::manager::tests` → **213 passed, 3 ignored** (no regressions)

## Related

- Plan `e81fb4de-62b5-4d6e-a370-a12c303f81a7` — Dependabot security audit (T1)
- Stacks on top of #244 (T0 — remove stale desktop lockfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)