### PR TITLE
chore(deps): bump rustls-webpki 0.103.13 + async-nats 0.47 (closes 2 alerts, contributes to 2 more)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5af9ebfb0a14481d3eaf6101e6391261e4f30d25b26a7635ade8a39482ded0"
+checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -268,15 +268,14 @@ dependencies = [
  "memchr",
  "nkeys",
  "nuid",
- "once_cell",
  "pin-project",
  "portable-atomic",
  "rand 0.8.5",
  "regex",
  "ring",
- "rustls-native-certs 0.7.3",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.13",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -1570,7 +1569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3095,11 +3094,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
- "rayon",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3107,7 +3101,10 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
+ "rayon",
 ]
 
 [[package]]
@@ -3457,7 +3454,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3641,7 +3638,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "rayon",
  "serde",
 ]
 
@@ -3653,6 +3649,7 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "rayon",
  "serde",
  "serde_core",
 ]
@@ -5358,7 +5355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6963,7 +6960,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -7035,7 +7032,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -7060,19 +7057,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7093,8 +7080,8 @@ checksum = "f8a4717d3df536ce531369b8c9a0c7f9624a51cf9c3948038ed3cb18e9a16c92"
 dependencies = [
  "ahash",
  "fixedbitset",
- "hashbrown 0.14.5",
- "indexmap 1.9.3",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
  "ndarray 0.16.1",
  "num-traits",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ dirs = "6"
 regex = "1.12.3"
 
 # NATS message broker (inter-process event sync)
-async-nats = "0.46"
+async-nats = "0.47"
 
 # Config
 dotenvy = "0.15"


### PR DESCRIPTION
## Summary

Two functionally-coupled bumps in one PR:
1. `cargo update -p rustls-webpki@0.103.10 --precise 0.103.13`
2. Direct: `async-nats = "0.46"` → `"0.47"` in workspace Cargo.toml

## GHSAs addressed

| GHSA | Sev | Closes via |
|---|---|---|
| GHSA-82j2-j2ch-gfr8 | high | rustls-webpki 0.103.13 directly |
| GHSA-pwjx-qhcg-rvj4 | medium | 0.103.13 bump + async-nats bump (kills 0.102.x) |
| GHSA-xgp8-3hg3-c2mh | low | needs both 0.101.7 and 0.102.8 gone. **0.102.8 eliminated here** (async-nats); 0.101.7 needs T5 (reqwest 0.12 in nexus). |
| GHSA-965h-392x-2mh5 | low | same |

After this PR + T5 ship, all 4 webpki alerts close.

## Cargo.lock impact (verified)

```
- rustls-webpki v0.102.8   (gone — async-nats 0.47 uses webpki 0.103+)
+ rustls-webpki v0.103.13  (was 0.103.10, security-patched)
+ async-nats v0.47.0       (was 0.46.0)
```

Remaining: `rustls-webpki v0.101.7` (pulled by reqwest 0.11 ← nexus-claude). Will be removed in T5.

## Breaking change audit

### rustls-webpki 0.103.13 — pure security patch series ✅
- 0.103.13: fixes GHSA-82j2 (CRL panic)
- 0.103.12: fixes name constraints (URI/wildcard)
- 0.103.11: relaxes unknown critical extensions parsing (additive)

### async-nats 0.47 — minor with Subject Validation ⚠️ low risk

Per [v0.47.0 release notes](https://github.com/nats-io/nats.rs/releases/tag/async-nats%2Fv0.47.0):
- ⚠️ Adds Subject Validation against NATS rules (alnum + `.` + `_` + `-`)
- Updates rustls-webpki to 0.103+
- Bumps `rustls-native-certs` 0.7 → 0.8 (transitive)
- Removes `once_cell` for `std::sync::LazyLock`

Our subjects (`src/events/nats.rs`) use `format!("{}.chat.{}", prefix, session_id)` where `session_id` is a UUID — fully conformant. No code change needed. If validation surfaces edge cases in production, async-nats 0.47 provides an opt-out via `ConnectOptions`.

## Verification

- `cargo check --lib --tests` — green
- `cargo test --lib chat::manager::tests` → **213/213** passed (no regression)
- `cargo tree --package rustls-webpki@0.102.8` — empty post-update
- Cargo.lock shows `async-nats 0.47.0` + `rustls-webpki 0.103.13`

## Related

- Plan `e81fb4de-62b5-4d6e-a370-a12c303f81a7` — Dependabot security audit (T2)
- Cross-ref T5 (jsonwebtoken multi-repo) closes the residual webpki 0.101.7 lows

🤖 Generated with [Claude Code](https://claude.com/claude-code)