### PR TITLE
fix(chat): Windows stubs for unix-only descendant PID tracking

### DIFF
--- a/src/chat/manager.rs
+++ b/src/chat/manager.rs
@@ -6538,6 +6538,17 @@ impl ChatManager {
         result
     }
 
+    /// Windows stub for `get_descendant_pids` — descendant tracking relies
+    /// on `pgrep -P <pid>` (POSIX-specific). Windows would need a different
+    /// implementation (e.g. `wmic process` or the `Toolhelp32` API). The
+    /// runtime feature this powers (V2 cancel-tools subtree termination)
+    /// is currently Unix-only, so we no-op cleanly on Windows: callers
+    /// receive an empty Vec and skip the descendant-aware code paths.
+    #[cfg(windows)]
+    fn get_descendant_pids(_pid: u32) -> Vec<u32> {
+        Vec::new()
+    }
+
     /// Parse the `[[dd-]hh:]mm:ss` format returned by `ps -o etime=` into a
     /// total elapsed-seconds count. Plan fc35b25e (T1, V2 cancel_task).
     ///
@@ -6598,6 +6609,16 @@ impl ChatManager {
         }
         let raw = String::from_utf8(output.stdout).ok()?;
         Self::parse_etime(&raw)
+    }
+
+    /// Windows stub for `process_etime_seconds` — `ps -o etime=` doesn't
+    /// exist on Windows. Caller `pid_discovery_diff` uses this only as a
+    /// sort key and substitutes `u64::MAX` on `None`, so returning `None`
+    /// here keeps PIDs in their original (unsorted) order on Windows.
+    #[cfg(windows)]
+    #[allow(dead_code)]
+    pub(crate) fn process_etime_seconds(_pid: u32) -> Option<u64> {
+        None
     }
 
     /// Compute `after \ before` (set difference, treating each `Vec` as a


### PR DESCRIPTION
## Summary

Hotfix for the **v0.0.13 release build** that failed on `x86_64-pc-windows-msvc` (run [25264186840](https://github.com/this-rs/project-orchestrator/actions/runs/25264186840/job/74076168400)) with 3 compilation errors. After this lands, `v0.0.13` can be retagged and the release pipeline will complete.

## Root cause

`ChatManager::get_descendant_pids` and `ChatManager::process_etime_seconds` are gated by `#[cfg(unix)]` (they shell out to `pgrep -P` and `ps -o etime=` respectively). But they were called from 3 cross-platform call sites with no cfg gate:

| Line | Function | Method called |
|------|----------|---------------|
| 3101 | `track_background_task_start` | `get_descendant_pids` |
| 3234 | `async_pid_claim` | `get_descendant_pids` |
| 6630 | `pid_discovery_diff` | `process_etime_seconds` |

The companion functions `kill_descendants` and `kill_subtree` already wrap their `get_descendant_pids` calls in `#[cfg(unix)] { … } #[cfg(not(unix))] { … }` blocks — they were never broken.

## Fix

Add `#[cfg(windows)]` no-op stubs matching the unix signatures:

```rust
#[cfg(windows)]
fn get_descendant_pids(_pid: u32) -> Vec<u32> {
    Vec::new()
}

#[cfg(windows)]
#[allow(dead_code)]
pub(crate) fn process_etime_seconds(_pid: u32) -> Option<u64> {
    None
}
```

## Behavioral impact on Windows

- `track_background_task_start` / `async_pid_claim` get an empty before/after snapshot → the descendant-aware claim lookup falls through to the existing non-descendant code path. The **V2 cancel-tools subtree-termination feature was already Unix-only** — this preserves that.
- `pid_discovery_diff` sorts every PID by `u64::MAX` → original order preserved (etime tiebreaker disabled).

A future port could implement these via `wmic process` or the `Toolhelp32` API.

## Verification

- `cargo check --lib` green on macOS
- Cross-compile to `x86_64-pc-windows-gnu` requires the full GNU Windows toolchain (not installed locally). Relying on the GitHub Actions Windows runner to confirm via the next `v0.0.13` tag push.

## Sequencing

1. Merge this PR
2. `git tag --delete v0.0.13` locally + `git push origin :v0.0.13` to remove the broken tag
3. Re-tag `v0.0.13` from new main → release pipeline restarts with the fix included

🤖 Generated with [Claude Code](https://claude.com/claude-code)