### PR TITLE
fix(chat): persist mid-session model switch so resume honors it

### DIFF
--- a/src/api/ws_chat_handler.rs
+++ b/src/api/ws_chat_handler.rs
@@ -978,31 +978,29 @@ async fn handle_ws_chat_loop(
 
                                     WsChatClientMessage::SetModel { model } => {
                                         info!(session_id = %session_id, model = %model, "WS: Received set_model");
-                                        if chat_manager.is_session_active(&session_id).await {
-                                            match chat_manager.set_session_model(&session_id, &model).await {
-                                                Ok(()) => {
-                                                    // Send confirmation back to frontend
-                                                    let confirmation = serde_json::json!({
-                                                        "type": "model_changed",
-                                                        "model": model,
-                                                    });
-                                                    let _ = ws_sender.send(Message::Text(confirmation.to_string().into())).await;
-                                                }
-                                                Err(e) => {
-                                                    warn!(session_id = %session_id, error = %e, "Failed to set model");
-                                                    let err = serde_json::json!({
-                                                        "type": "error",
-                                                        "message": format!("Failed to set model: {}", e),
-                                                    });
-                                                    let _ = ws_sender.send(Message::Text(err.to_string().into())).await;
-                                                }
+                                        // set_model works whether the session is active or dormant:
+                                        // - Active: sends a live control_request to switch mid-conversation.
+                                        // - Dormant (idle-cleaned): persists to Neo4j so the next resume/spawn
+                                        //   launches with the chosen model.
+                                        // Previously this was gated on is_session_active, so selecting a model
+                                        // on an idle session was silently rejected and the respawn used the
+                                        // create-time model. set_session_model now handles both cases.
+                                        match chat_manager.set_session_model(&session_id, &model).await {
+                                            Ok(()) => {
+                                                let confirmation = serde_json::json!({
+                                                    "type": "model_changed",
+                                                    "model": model,
+                                                });
+                                                let _ = ws_sender.send(Message::Text(confirmation.to_string().into())).await;
                                             }
-                                        } else {
-                                            let err = serde_json::json!({
-                                                "type": "error",
-                                                "message": "Session not active on this instance",
-                                            });
-                                            let _ = ws_sender.send(Message::Text(err.to_string().into())).await;
+                                            Err(e) => {
+                                                warn!(session_id = %session_id, error = %e, "Failed to set model");
+                                                let err = serde_json::json!({
+                                                    "type": "error",
+                                                    "message": format!("Failed to set model: {}", e),
+                                                });
+                                                let _ = ws_sender.send(Message::Text(err.to_string().into())).await;
+                                            }
                                         }
                                     }
 

--- a/src/chat/manager.rs
+++ b/src/chat/manager.rs
@@ -5060,54 +5060,94 @@ impl ChatManager {
     /// `stream_response` holds the client lock for the entire duration of streaming.
     /// If we tried to lock the client here, the WS event loop would deadlock.
     pub async fn set_session_model(&self, session_id: &str, model: &str) -> Result<()> {
-        // Get session state and stdin_tx — do NOT extract client (avoids Mutex deadlock)
-        let (stdin_tx, old_model, events_tx) = {
+        // Capture the live session's stdin_tx + events_tx IF the CLI subprocess is still
+        // attached. A dormant session (idle-cleaned) won't be present in `active_sessions`
+        // — that is NOT an error: we still persist the chosen model to Neo4j below so the
+        // next resume/spawn launches with it. Do NOT extract `client` (avoids Mutex deadlock).
+        let live = {
             let mut sessions = self.active_sessions.write().await;
-            let session = sessions
-                .get_mut(session_id)
-                .ok_or_else(|| anyhow!("Session {} not found or inactive", session_id))?;
-            session.last_activity = Instant::now();
-            let old_model = session.model.clone();
-            session.model = Some(model.to_string());
-            let tx = session.stdin_tx.clone().ok_or_else(|| {
-                anyhow!(
-                    "No stdin sender for session {} (CLI may not be connected)",
-                    session_id
-                )
-            })?;
-            (tx, old_model, session.events_tx.clone())
+            match sessions.get_mut(session_id) {
+                Some(session) => {
+                    session.last_activity = Instant::now();
+                    let old_model = session.model.clone();
+                    session.model = Some(model.to_string());
+                    Some((
+                        session.stdin_tx.clone(),
+                        old_model,
+                        session.events_tx.clone(),
+                    ))
+                }
+                None => None,
+            }
         };
 
-        // Build the control_request JSON — same format as InteractiveClient::set_model
-        let control_request = serde_json::json!({
-            "type": "control_request",
-            "request_id": Uuid::new_v4().to_string(),
-            "request": {
-                "subtype": "set_model",
-                "model": model
+        // Persist to Neo4j ALWAYS. This is the core fix: previously the model was updated
+        // in-memory only, so it was silently lost on idle-cleanup → resume respawned on the
+        // create-time model. `resume_session` reads `s.model` back from Neo4j (manager line
+        // ~5271 → build_options.model), so persisting here makes the switch durable.
+        if let Ok(uuid) = Uuid::parse_str(session_id) {
+            if let Err(e) = self.graph.update_chat_session_model(uuid, model).await {
+                warn!(
+                    session_id = %session_id,
+                    error = %e,
+                    "Failed to persist model change to Neo4j (non-fatal)"
+                );
             }
-        });
+        }
 
-        let json = serde_json::to_string(&control_request)
-            .map_err(|e| anyhow!("Failed to serialize set_model request: {}", e))?;
+        match live {
+            // Active session with a live CLI: switch the running model mid-conversation.
+            Some((Some(stdin_tx), old_model, events_tx)) => {
+                // Build the control_request JSON — same format as InteractiveClient::set_model
+                let control_request = serde_json::json!({
+                    "type": "control_request",
+                    "request_id": Uuid::new_v4().to_string(),
+                    "request": {
+                        "subtype": "set_model",
+                        "model": model
+                    }
+                });
 
-        // Send via stdin_tx (lock-free — bypasses the client Mutex entirely)
-        stdin_tx
-            .send(json)
-            .await
-            .map_err(|e| anyhow!("Failed to send set_model to CLI: {}", e))?;
+                let json = serde_json::to_string(&control_request)
+                    .map_err(|e| anyhow!("Failed to serialize set_model request: {}", e))?;
 
-        info!(
-            session_id = %session_id,
-            old_model = ?old_model,
-            new_model = %model,
-            "Model changed for session (via stdin_tx, lock-free)"
-        );
+                // Send via stdin_tx (lock-free — bypasses the client Mutex entirely)
+                stdin_tx
+                    .send(json)
+                    .await
+                    .map_err(|e| anyhow!("Failed to send set_model to CLI: {}", e))?;
 
-        // Broadcast event to WebSocket clients
-        let _ = events_tx.send(ChatEvent::ModelChanged {
-            model: model.to_string(),
-        });
+                info!(
+                    session_id = %session_id,
+                    old_model = ?old_model,
+                    new_model = %model,
+                    "Model changed for active session (via stdin_tx, lock-free)"
+                );
+
+                let _ = events_tx.send(ChatEvent::ModelChanged {
+                    model: model.to_string(),
+                });
+            }
+            // Session present but CLI not connected yet — persisted; applies on next spawn.
+            Some((None, _, events_tx)) => {
+                info!(
+                    session_id = %session_id,
+                    new_model = %model,
+                    "Model persisted (no live CLI stdin); applies on next spawn"
+                );
+                let _ = events_tx.send(ChatEvent::ModelChanged {
+                    model: model.to_string(),
+                });
+            }
+            // Dormant session (idle-cleaned) — persisted to Neo4j only; applies on resume.
+            None => {
+                info!(
+                    session_id = %session_id,
+                    new_model = %model,
+                    "Model persisted for dormant session; applies on resume"
+                );
+            }
+        }
 
         Ok(())
     }
@@ -10441,11 +10481,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_set_session_model_fails_without_stdin() {
+    async fn test_set_session_model_without_stdin_persists_and_broadcasts() {
         let state = mock_app_state();
         let manager = ChatManager::new_without_memory(state.neo4j, state.meili, test_config());
         let (session, _handle) = mock_active_session(false);
-        // stdin_tx is None by default
+        // stdin_tx is None — no live CLI to receive a control_request. This must NOT error:
+        // the model is updated in-memory + persisted so it applies on the next spawn.
+
+        let mut events_rx = session.events_tx.subscribe();
 
         let session_id = "test-model-no-stdin";
         manager
@@ -10454,30 +10497,45 @@ mod tests {
             .await
             .insert(session_id.to_string(), session);
 
-        let result = manager
+        manager
             .set_session_model(session_id, "claude-opus-4-20250514")
-            .await;
+            .await
+            .expect("model change without live stdin should succeed (persist + broadcast)");
 
-        assert!(result.is_err());
-        assert!(
-            result.unwrap_err().to_string().contains("No stdin sender"),
-            "Error should mention missing stdin sender"
-        );
+        // In-memory model is updated so a respawn from this session uses the new model.
+        {
+            let sessions = manager.active_sessions.read().await;
+            assert_eq!(
+                sessions.get(session_id).unwrap().model.as_deref(),
+                Some("claude-opus-4-20250514")
+            );
+        }
+
+        // ModelChanged is still broadcast so the frontend reflects the choice.
+        let event = tokio::time::timeout(Duration::from_millis(100), events_rx.recv())
+            .await
+            .expect("should receive event within timeout")
+            .expect("channel should be open");
+        assert_eq!(event.event_type(), "model_changed");
     }
 
     #[tokio::test]
-    async fn test_set_session_model_fails_for_unknown_session() {
+    async fn test_set_session_model_dormant_session_persists() {
         let state = mock_app_state();
         let manager = ChatManager::new_without_memory(state.neo4j, state.meili, test_config());
 
+        // A session absent from active_sessions is dormant (idle-cleaned). set_model must
+        // still succeed by persisting to Neo4j so the next resume launches with the new
+        // model — rather than rejecting the change and respawning on the create-time model.
+        let session_id = uuid::Uuid::new_v4().to_string();
         let result = manager
-            .set_session_model("nonexistent-session", "claude-opus-4-20250514")
+            .set_session_model(&session_id, "claude-opus-4-20250514")
             .await;
 
-        assert!(result.is_err());
         assert!(
-            result.unwrap_err().to_string().contains("not found"),
-            "Error should mention session not found"
+            result.is_ok(),
+            "dormant session model change should persist without error, got {:?}",
+            result
         );
     }
 

--- a/src/neo4j/chat.rs
+++ b/src/neo4j/chat.rs
@@ -282,6 +282,22 @@ impl Neo4jClient {
         Ok(())
     }
 
+    /// Update the model field on a chat session node.
+    ///
+    /// The model is otherwise written only at create time, so a mid-session model
+    /// switch would be lost the moment the session went dormant and was resumed
+    /// (resume reads `s.model` back from Neo4j). Persisting here makes the chosen
+    /// model survive idle-cleanup and respawn.
+    pub async fn update_chat_session_model(&self, id: Uuid, model: &str) -> Result<()> {
+        let cypher =
+            "MATCH (s:ChatSession {id: $id}) SET s.model = $model, s.updated_at = datetime()";
+        let q = query(cypher)
+            .param("id", id.to_string())
+            .param("model", model.to_string());
+        self.graph.run(q).await?;
+        Ok(())
+    }
+
     /// Set the auto_continue flag on a chat session node.
     pub async fn set_session_auto_continue(&self, id: Uuid, enabled: bool) -> Result<()> {
         let cypher = "MATCH (s:ChatSession {id: $id}) SET s.auto_continue = $enabled, s.updated_at = datetime()";

--- a/src/neo4j/impl_graph_store.rs
+++ b/src/neo4j/impl_graph_store.rs
@@ -2229,6 +2229,10 @@ impl GraphStore for Neo4jClient {
         self.update_chat_session_permission_mode(id, mode).await
     }
 
+    async fn update_chat_session_model(&self, id: Uuid, model: &str) -> anyhow::Result<()> {
+        self.update_chat_session_model(id, model).await
+    }
+
     async fn set_session_auto_continue(&self, id: Uuid, enabled: bool) -> anyhow::Result<()> {
         self.set_session_auto_continue(id, enabled).await
     }

--- a/src/neo4j/mock.rs
+++ b/src/neo4j/mock.rs
@@ -6790,6 +6790,15 @@ impl GraphStore for MockGraphStore {
         Ok(())
     }
 
+    async fn update_chat_session_model(&self, id: Uuid, model: &str) -> Result<()> {
+        let mut sessions = self.chat_sessions.write().await;
+        if let Some(session) = sessions.get_mut(&id) {
+            session.model = model.to_string();
+            session.updated_at = Utc::now();
+        }
+        Ok(())
+    }
+
     async fn set_session_auto_continue(&self, id: Uuid, enabled: bool) -> Result<()> {
         let mut auto_continue = self.session_auto_continue.write().await;
         auto_continue.insert(id, enabled);

--- a/src/neo4j/traits.rs
+++ b/src/neo4j/traits.rs
@@ -1841,6 +1841,10 @@ pub trait GraphStore: Send + Sync {
     /// Update the permission_mode field on a chat session node
     async fn update_chat_session_permission_mode(&self, id: Uuid, mode: &str) -> Result<()>;
 
+    /// Update the model field on a chat session node (so a mid-session model switch
+    /// survives idle-cleanup and is honored on resume/respawn)
+    async fn update_chat_session_model(&self, id: Uuid, model: &str) -> Result<()>;
+
     /// Set the auto_continue flag on a chat session node
     async fn set_session_auto_continue(&self, id: Uuid, enabled: bool) -> Result<()>;
 


### PR DESCRIPTION
## Summary
Selecting a different model in the chat UI (e.g. Opus 4.8) did not take effect: the session stayed/relaunched on its **create-time** model. The user's session JSONL showed every assistant message on the old model with **zero** `set_model`/`control_request` traces.

Two convergent bugs in the `set_model` path:

1. **`set_session_model` never persisted to Neo4j** — it mutated the in-memory `active_sessions` map only. `resume_session` reads `session_node.model` back from Neo4j (→ `build_options.model` → CLI `--model`), so once a session went dormant (idle-cleanup kills the CLI subprocess) the chosen model was lost and the respawn used the create-time model. (`set_session_permission_mode` already persisted; `set_session_model` was the asymmetric one.)
2. **The WS `SetModel` handler was gated on `is_session_active`** — a dormant session returned "Session not active" and `set_session_model` was never even called (hence zero traces). The sibling `set_auto_continue` arm was deliberately written to work active *or* idle.

## Changes
- Add `GraphStore::update_chat_session_model` (Neo4jClient + MockGraphStore), mirroring `update_chat_session_permission_mode`. `update_chat_session` itself has no model param — model was previously written only at create time.
- Rewrite `set_session_model`: **persist to Neo4j always**; send the live `control_request` only when the CLI stdin is attached; tolerate dormant/no-stdin sessions (persist + broadcast `ModelChanged`, return `Ok`).
- Drop the `is_session_active` gate in the WS `SetModel` arm; `set_session_model` now decides per-case.
- Tests updated to encode the new behavior (persist without stdin; dormant session persists).

## Test plan
- [x] `cargo check --lib` on `main` base
- [x] `cargo test --lib set_session_model` → 3/3 pass
- [ ] Live: select a new model on an **active** session → switches mid-conversation (verify via session JSONL `"model"`, not `ps` argv).
- [ ] Live: select a new model on a **dormant** session → next message respawns on the new model.

## Notes
- Authoritative effective-model source is the session JSONL `"model"` field; `ps` argv shows only the spawn-time model and never reflects runtime control-protocol switches.
- Pairs with frontend PR this-rs/project-orchestrator-frontend#137 (adds Opus 4.8 to the selector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)