### PR TITLE
feat(runner): bound wave concurrency with a configurable cap

### DIFF
--- a/src/runner/models.rs
+++ b/src/runner/models.rs
@@ -50,6 +50,14 @@ pub struct RunnerConfig {
     /// Maximum number of auto-continue cycles before giving up. Default: 5.
     /// Prevents infinite loops when the agent keeps hitting error_max_turns.
     pub max_auto_continues: u32,
+    /// Maximum number of tasks executed concurrently within a single wave. Default: 4.
+    /// A wave can contain many independent tasks; without a cap the runner would spawn
+    /// one Claude Code session per task simultaneously (unbounded fan-out → cost spikes,
+    /// API rate limits, host saturation). Tasks beyond the cap queue on a semaphore and
+    /// start as permits free up. Set to `0` for unlimited (legacy behaviour, not advised).
+    /// This is also the prerequisite for safely hosting intra-task Dynamic Workflows,
+    /// which themselves fan out up to 16 sub-agents per session.
+    pub max_parallel_tasks: usize,
 }
 
 /// CWD validation mode for the runner.
@@ -78,6 +86,7 @@ impl Default for RunnerConfig {
             completion_loop_threshold: 5,
             completion_max_chars: 200,
             max_auto_continues: 5,
+            max_parallel_tasks: 4,
         }
     }
 }

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -1420,6 +1420,24 @@ impl PlanRunner {
 
         let mut join_set: JoinSet<(Uuid, String, Result<TaskExecutionResult>)> = JoinSet::new();
 
+        // Concurrency cap: throttle how many tasks in this wave run their agent
+        // session simultaneously. All eligible tasks are still spawned immediately,
+        // but each one acquires a permit before doing real work, so at most
+        // `max_parallel_tasks` sessions are live at once. `0` = unlimited (legacy).
+        let task_semaphore = match self.config.max_parallel_tasks {
+            0 => None,
+            n => {
+                if eligible_tasks.len() > n {
+                    info!(
+                        "Wave has {} eligible tasks; throttling to {} concurrent (max_parallel_tasks)",
+                        eligible_tasks.len(),
+                        n
+                    );
+                }
+                Some(std::sync::Arc::new(tokio::sync::Semaphore::new(n)))
+            }
+        };
+
         for wave_task in &eligible_tasks {
             let task_id = wave_task.id;
             let task_title = wave_task
@@ -1481,8 +1499,15 @@ impl PlanRunner {
             let project_slug = project_slug.map(|s| s.to_string());
             let title_clone = task_title.clone();
             let continuity = continuity_context.to_string();
+            let task_semaphore = task_semaphore.clone();
 
             join_set.spawn(async move {
+                // Acquire a concurrency permit (held for the whole task) when a cap
+                // is configured. Tasks beyond the cap park here until a permit frees.
+                let _permit = match task_semaphore {
+                    Some(sem) => sem.acquire_owned().await.ok(),
+                    None => None,
+                };
                 let result = runner
                     .execute_task(
                         run_id,
@@ -4319,6 +4344,66 @@ mod tests {
             *global = None;
         }
         RUNNER_CANCEL.store(false, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn test_default_max_parallel_tasks_is_bounded() {
+        // The runner must NOT default to unbounded wave fan-out. A finite cap is the
+        // prerequisite for coordinated multi-scale execution and for safely hosting
+        // intra-task Dynamic Workflows (which themselves fan out up to 16 sub-agents).
+        let cfg = RunnerConfig::default();
+        assert_eq!(cfg.max_parallel_tasks, 4);
+        assert_ne!(
+            cfg.max_parallel_tasks, 0,
+            "0 means unlimited; must not be the default"
+        );
+    }
+
+    /// Pins the throttle invariant used by `execute_wave`: with a semaphore of N
+    /// permits, no more than N spawned tasks run their critical section concurrently,
+    /// while all of them still eventually complete. This mirrors the exact
+    /// `Arc<Semaphore>` + `acquire_owned()` pattern guarding agent-session spawns.
+    #[tokio::test]
+    async fn test_wave_semaphore_caps_concurrency() {
+        use std::sync::atomic::{AtomicUsize, Ordering as AOrd};
+        use tokio::task::JoinSet;
+
+        const CAP: usize = 4;
+        const TASKS: usize = 20;
+
+        let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(CAP));
+        let live = std::sync::Arc::new(AtomicUsize::new(0));
+        let peak = std::sync::Arc::new(AtomicUsize::new(0));
+        let done = std::sync::Arc::new(AtomicUsize::new(0));
+
+        let mut join_set: JoinSet<()> = JoinSet::new();
+        for _ in 0..TASKS {
+            let sem = sem.clone();
+            let live = live.clone();
+            let peak = peak.clone();
+            let done = done.clone();
+            join_set.spawn(async move {
+                let _permit = sem.acquire_owned().await.ok();
+                let now = live.fetch_add(1, AOrd::SeqCst) + 1;
+                peak.fetch_max(now, AOrd::SeqCst);
+                // Hold the permit across an await point, like a real task session.
+                tokio::time::sleep(std::time::Duration::from_millis(15)).await;
+                live.fetch_sub(1, AOrd::SeqCst);
+                done.fetch_add(1, AOrd::SeqCst);
+            });
+        }
+        while join_set.join_next().await.is_some() {}
+
+        assert_eq!(done.load(AOrd::SeqCst), TASKS, "every task must complete");
+        assert!(
+            peak.load(AOrd::SeqCst) <= CAP,
+            "peak concurrency {} exceeded cap {CAP}",
+            peak.load(AOrd::SeqCst)
+        );
+        assert!(
+            peak.load(AOrd::SeqCst) >= 2,
+            "with {TASKS} tasks and cap {CAP}, some real parallelism should occur"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- The plan runner spawned **one Claude Code session per task in a wave with no upper bound** (unbounded `tokio::JoinSet` fan-out in `execute_wave`). A wide wave could launch many subprocesses simultaneously → cost spikes, API rate limits, host saturation, and no conscious coordination across scales.
- Adds `RunnerConfig.max_parallel_tasks` (**default 4**, `0` = unlimited legacy escape hatch). Each task now acquires a permit from a per-wave `tokio::sync::Semaphore` before doing real work and holds it for the task's whole lifetime, so at most N agent sessions are live at once while every task still runs to completion.
- This is the **prerequisite for safely hosting intra-task Claude Code Dynamic Workflows** later: each workflow itself fans out up to 16 sub-agents, so the macro-orchestrator must cap its own fan-out before nesting another layer.

## Context — Dynamic Workflows audit
While scoping a Dynamic Workflows integration, an audit found native workflows are **not reachable today**: the installed CLI is `2.1.138` (workflows need `v2.1.154+`), and the Nexus SDK silently drops unknown control messages (no workflow-event relay). Rather than write dead activation code, this PR lands the one improvement that is universally correct, testable now, and unblocks that future work: bounded, coordinated wave execution.

## Changes
- `src/runner/models.rs` — new `max_parallel_tasks` field + default (4) + doc.
- `src/runner/runner.rs` — per-wave semaphore gate in `execute_wave`; permit held across the task await.

## Test plan
- [x] `cargo check --lib` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `test_default_max_parallel_tasks_is_bounded` — default is finite (4), never 0
- [x] `test_wave_semaphore_caps_concurrency` — peak concurrency never exceeds the cap; all tasks complete; real parallelism still occurs
- [ ] Behavioural check on a real multi-task wave once merged (cost/rate-limit smoothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)