### PR TITLE
feat(chat): surface Claude Code Dynamic Workflow progress events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4628,7 +4628,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 [[package]]
 name = "nexus-claude"
 version = "0.5.0"
-source = "git+https://github.com/this-rs/nexus.git?rev=59f8c17c0d9be2ad5492d3b097cca6e0f00be649#59f8c17c0d9be2ad5492d3b097cca6e0f00be649"
+source = "git+https://github.com/this-rs/nexus.git?rev=8b907031debc784f2e7192d26be5ee988d20b2ab#8b907031debc784f2e7192d26be5ee988d20b2ab"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ async-trait = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # Chat / Claude Code SDK
-nexus-claude = { git = "https://github.com/this-rs/nexus.git", rev = "59f8c17c0d9be2ad5492d3b097cca6e0f00be649", features = ["memory", "auto-download"] }
+nexus-claude = { git = "https://github.com/this-rs/nexus.git", rev = "8b907031debc784f2e7192d26be5ee988d20b2ab", features = ["memory", "auto-download"] }
 tokio-stream = { workspace = true }
 
 # Auth

--- a/src/chat/manager.rs
+++ b/src/chat/manager.rs
@@ -2406,6 +2406,17 @@ impl ChatManager {
                             pre_tokens,
                         }]
                     }
+                    // Claude Code Dynamic Workflow lifecycle events (intra-task
+                    // sub-agent fan-out via the `Workflow` tool). These arrive as
+                    // flat system messages; forward subtype + full payload so the
+                    // frontend can render live fan-out progress. (Requires the SDK
+                    // to preserve the flat payload — nexus PR #31.)
+                    "task_started" | "task_progress" | "task_updated" | "task_notification" => {
+                        vec![ChatEvent::Workflow {
+                            subtype: subtype.clone(),
+                            data: data.clone(),
+                        }]
+                    }
                     _ => {
                         debug!("Unhandled system message: {} — {:?}", subtype, data);
                         vec![]

--- a/src/chat/types.rs
+++ b/src/chat/types.rs
@@ -503,6 +503,21 @@ pub enum ChatEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         permission_mode: Option<String>,
     },
+    /// Claude Code Dynamic Workflow lifecycle event (intra-task sub-agent fan-out).
+    ///
+    /// Emitted when the session's agent runs the `Workflow` tool, which spawns
+    /// background sub-agents. Carries the workflow lifecycle `subtype`
+    /// (`task_started` / `task_progress` / `task_updated` / `task_notification`)
+    /// and the full payload preserved from the CLI system message — task_id,
+    /// workflow_name, `workflow_progress[]` (per-agent fan-out state), usage,
+    /// status, output_file, patch. Passed through verbatim so the frontend can
+    /// render live fan-out progress without the backend pinning a schema.
+    Workflow {
+        /// Workflow lifecycle subtype, e.g. "task_started", "task_progress".
+        subtype: String,
+        /// Full event payload as emitted by the CLI (passed through verbatim).
+        data: serde_json::Value,
+    },
     /// Backend auto-continue: emitted when the backend detects error_max_turns
     /// and auto_continue is enabled. Signals that a "Continue" will be sent
     /// automatically after the delay.
@@ -654,6 +669,7 @@ impl ChatEvent {
             ChatEvent::CompactionRecovery { .. } => "compaction_recovery",
             ChatEvent::CompactBoundary { .. } => "compact_boundary",
             ChatEvent::SystemInit { .. } => "system_init",
+            ChatEvent::Workflow { .. } => "workflow",
             ChatEvent::AutoContinue { .. } => "auto_continue",
             ChatEvent::AutoContinueStateChanged { .. } => "auto_continue_state_changed",
             ChatEvent::Retrying { .. } => "retrying",
@@ -684,6 +700,19 @@ impl ChatEvent {
             ChatEvent::PermissionDecision { id, .. } => Some(format!("permission_decision:{}", id)),
             ChatEvent::SystemInit { cli_session_id, .. } => {
                 Some(format!("system_init:{}", cli_session_id))
+            }
+            ChatEvent::Workflow { subtype, data } => {
+                // Each CLI workflow event carries a unique `uuid`; dedup on it so
+                // a replay never collapses distinct task_progress ticks. Fall back
+                // to subtype + content hash if no uuid is present.
+                if let Some(uuid) = data.get("uuid").and_then(|v| v.as_str()) {
+                    Some(format!("workflow:{}", uuid))
+                } else {
+                    use std::hash::{Hash, Hasher};
+                    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                    data.to_string().hash(&mut hasher);
+                    Some(format!("workflow:{}:{}", subtype, hasher.finish()))
+                }
             }
 
             // Events without unique IDs — use type + content hash
@@ -1382,6 +1411,43 @@ mod tests {
         assert!(json.contains("Hello!"));
         // parent_tool_use_id: None should NOT appear in JSON
         assert!(!json.contains("parent_tool_use_id"));
+    }
+
+    #[test]
+    fn test_workflow_event_serialize_and_dedup() {
+        let event = ChatEvent::Workflow {
+            subtype: "task_progress".into(),
+            data: serde_json::json!({
+                "task_id": "wbk63ch2d",
+                "uuid": "ed4e206c-974c-4883-93d3-de4c892e12a9",
+                "workflow_progress": [{ "index": 1, "state": "start" }],
+                "usage": { "total_tokens": 7681 }
+            }),
+        };
+
+        // Serde tag + subtype + nested payload survive serialization.
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"type\":\"workflow\""));
+        assert!(json.contains("\"subtype\":\"task_progress\""));
+        assert!(json.contains("wbk63ch2d"));
+        assert!(json.contains("workflow_progress"));
+
+        assert_eq!(event.event_type(), "workflow");
+
+        // Fingerprint keys on the unique per-event uuid, so distinct progress ticks
+        // are never collapsed on replay.
+        assert_eq!(
+            event.fingerprint().as_deref(),
+            Some("workflow:ed4e206c-974c-4883-93d3-de4c892e12a9")
+        );
+
+        // Without a uuid, fingerprint falls back to subtype + content hash (still Some).
+        let no_uuid = ChatEvent::Workflow {
+            subtype: "task_started".into(),
+            data: serde_json::json!({ "task_id": "x" }),
+        };
+        let key = no_uuid.fingerprint().unwrap();
+        assert!(key.starts_with("workflow:task_started:"));
     }
 
     #[test]

--- a/src/runner/prompt.rs
+++ b/src/runner/prompt.rs
@@ -438,6 +438,10 @@ Your ONLY job is to **write code, test it, and commit it**. You are NOT in a con
 8. If tests are mentioned in steps, run them. If `cargo check` or tests fail, fix the errors and retry — do not give up.
 9. When done with ALL steps, make a final commit summarizing the work.
 
+## Parallel sub-agents (optional — Dynamic Workflows)
+
+For a task with **independent, parallelizable sub-parts** (e.g. the same mechanical change across several unrelated files/modules), you MAY use the **`Workflow` tool** to fan out sub-agents instead of working sequentially. Use it ONLY when the sub-parts are genuinely independent AND the task is large enough to justify the overhead — for small or tightly-coupled work, just edit directly. The PlanRunner already parallelizes ACROSS tasks, so never use a workflow for work that should be its own task. Keep the fan-out modest; the runner caps concurrency for a reason.
+
 ## Execution Flow
 
 1. Read the task description and steps provided in the user message


### PR DESCRIPTION
## Summary
When a session's agent runs the **`Workflow` tool**, Claude Code (CLI ≥ 2.1.154) spawns background sub-agents and streams lifecycle events as flat `system` messages — subtypes `task_started` / `task_progress` / `task_updated` / `task_notification` — carrying task id, **per-agent fan-out state** (`workflow_progress[]`), usage, and completion status.

`ChatManager::message_to_events` previously matched only `init` and `compact_boundary` system subtypes and dropped the rest, so workflow fan-out was **invisible** to PO and its UI.

This PR makes that progress observable — the ChatManager (micro) half of letting PO consciously coordinate workflows, complementing the wave runner (macro).

## Changes
- **`ChatEvent::Workflow { subtype, data }`** (`src/chat/types.rs`) — forwards the subtype plus the full CLI payload **verbatim** (no backend schema pinning), so the frontend can render live fan-out without the backend chasing CLI shape changes. Fingerprinted on the event's unique `uuid` so replays never collapse distinct `task_progress` ticks (content-hash fallback when absent).
- **Routing** (`src/chat/manager.rs`) — the four workflow subtypes now emit `ChatEvent::Workflow`. Persists via the existing `store_chat_events` chain and serializes to WS automatically.
- **Runner prompt** (`src/runner/prompt.rs`) — mentions the `Workflow` tool as an *optional, measured* intra-task fan-out tool, with explicit guardrails (the runner already parallelizes across tasks and caps wave concurrency, so don't use a workflow for work that should be its own task).

## Empirical basis (CLI 2.1.159)
A real headless workflow run emits, e.g.:
```json
{"type":"system","subtype":"task_progress","task_id":"wbk63ch2d",
 "workflow_progress":[{"type":"workflow_agent","index":1,"state":"start"}],
 "usage":{"total_tokens":7681,"duration_ms":1400},"uuid":"ed4e206c-...","session_id":"..."}
```

## Dependency
Requires **nexus PR #31** (`fix/sdk-relay-workflow-system-events`) — the SDK must preserve the flat system payload, otherwise `data` arrives empty. **Bump the backend's nexus rev once #31 merges** (currently pinned at `59f8c17`).

## Related
- PO #306 — `max_parallel_tasks` wave concurrency cap (the macro floor before nesting ≤16-agent workflows).
- nexus #31 — SDK payload preservation (the wire dependency above).

## Test plan
- [x] `cargo check --lib` clean (exhaustive `ChatEvent` matches updated)
- [x] `cargo fmt --check` clean
- [x] `cargo test --lib chat::types` — 72 passed
- [x] New `test_workflow_event_serialize_and_dedup` — serde tag + subtype + nested payload survive; fingerprint keys on uuid with hash fallback
- [ ] End-to-end WS render once #31 merges + rev bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)