### PR TITLE
fix(heartbeat): timeout_override for deep_maintenance so periodic skill creation lands

### DIFF
--- a/src/heartbeat/checks/maintenance.rs
+++ b/src/heartbeat/checks/maintenance.rs
@@ -13,6 +13,15 @@ use tracing::{debug, info, warn};
 use crate::heartbeat::{HeartbeatCheck, HeartbeatContext};
 use crate::skills::maintenance::SkillMaintenanceConfig;
 
+/// Per-run timeout for deep maintenance.
+///
+/// `deep_maintenance` runs Louvain community detection + skill-evolution
+/// analysis + persistence across ALL projects, which cannot complete within
+/// the engine's 5s default. Without this override the run is cancelled every
+/// tick and `last_run` is never updated (see engine.rs), so it retries-and-
+/// times-out forever — meaning periodic skill detection/evolution never lands.
+const MAINTENANCE_TIMEOUT: Duration = Duration::from_secs(5 * 60); // 5 minutes
+
 /// Run deep maintenance on all projects (every 24 hours).
 pub struct MaintenanceCheck;
 
@@ -24,6 +33,10 @@ impl HeartbeatCheck for MaintenanceCheck {
 
     fn interval(&self) -> Duration {
         Duration::from_secs(24 * 60 * 60) // 24 hours
+    }
+
+    fn timeout_override(&self) -> Option<Duration> {
+        Some(MAINTENANCE_TIMEOUT)
     }
 
     async fn run(&self, ctx: &HeartbeatContext) -> Result<()> {
@@ -115,5 +128,18 @@ mod tests {
     fn test_maintenance_check_interval() {
         let check = MaintenanceCheck;
         assert_eq!(check.interval(), Duration::from_secs(24 * 3600));
+    }
+
+    #[test]
+    fn test_maintenance_check_timeout_override() {
+        // Must override the engine's 5s default, otherwise deep_maintenance
+        // (Louvain + evolution across all projects) is cancelled every tick and
+        // last_run is never updated → periodic skill creation never lands.
+        let check = MaintenanceCheck;
+        assert_eq!(check.timeout_override(), Some(Duration::from_secs(300)));
+        assert!(
+            check.timeout_override().unwrap() > Duration::from_secs(5),
+            "must exceed the engine default timeout"
+        );
     }
 }


### PR DESCRIPTION
## Summary
`MaintenanceCheck` (24h interval) runs `skills::maintenance::deep_maintenance` — Louvain community detection + skill-evolution analysis + persistence across **all** projects — but defined **no `timeout_override`**, so it inherited the heartbeat engine's **5s default** (`engine.rs:98`). That work cannot finish in 5s, so the engine cancelled it every tick and, on timeout, **deliberately does not update `last_run`** (`engine.rs:119-126`) → the check **retried-and-timed-out forever and never persisted**.

Net effect observed by the user: **"PO never creates skills"** — automatically. Creation only ever happened via the one-shot startup warm-up or a manual `admin detect_skills` call; the *continuous/periodic* path was dead.

Fix: add `timeout_override() -> Some(300s)`, mirroring `HomeostasisCheck`. `deep_maintenance` can now complete and update `last_run`, restoring continuous autonomous skill creation/evolution.

## How it was found
A 6-agent investigation workflow ranked candidate causes; this dead-periodic-path was then **empirically confirmed**: `admin detect_skills` on PO Backend returns `Success` (`19 notes / 30 synapses → 2 skills created`), proving the data prerequisites (synapse graph ≥ 15 notes) are met and the *only* blocker for ongoing creation was the starved heartbeat check.

## Changes
- `src/heartbeat/checks/maintenance.rs`: `MAINTENANCE_TIMEOUT = 5min` const + `timeout_override()` + doc explaining the engine interaction.

## Test plan
- [x] `cargo test --lib heartbeat::checks::maintenance` — 3 passed (incl. new `test_maintenance_check_timeout_override` pinning `Some(300s) > 5s` default)
- [x] `cargo fmt --check` clean
- [ ] Runtime: after restart, confirm `deep_maintenance` completes (heartbeat log shows it no longer times out) and skill count grows without a manual `detect_skills`.

## Follow-ups (out of scope, noted from the diagnosis)
- For projects with a **sparse synapse graph**, automatic emergence still can't fire (needs embeddings + ≥15 synapse-connected notes). Consider lowering `min_notes_for_detection` (15→8) / `SynapseConfig.min_weight` (0.75→0.6) and wiring `admin backfill_synapses`. Also a doc-vs-code mismatch: `detection.rs:24` says cohesion 0.3 but code uses 0.5.
- Surface a loud startup warning when the embedding provider fails to init (currently a silent `None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)