### PR TITLE
fix(neural): self-heal the synapse graph so skill detection stops dying

### DIFF
--- a/src/heartbeat/checks/mod.rs
+++ b/src/heartbeat/checks/mod.rs
@@ -11,3 +11,4 @@ pub mod homeostasis;
 pub mod maintenance;
 pub mod staleness;
 pub mod synapse_decay;
+pub mod synapse_replenish;

--- a/src/heartbeat/checks/synapse_replenish.rs
+++ b/src/heartbeat/checks/synapse_replenish.rs
@@ -1,0 +1,111 @@
+//! SynapseReplenishCheck — rebuilds decayed-away synapses so the neural graph self-heals.
+//!
+//! `SynapseDecayCheck` (every 6h) and `deep_maintenance` decay + prune synapses
+//! unconditionally, but synapse CREATION is only **event-driven** (on note
+//! create/update — see `notes::manager::spawn_auto_connect_synapses`). Existing
+//! notes are never re-synapsed as decay erodes their links. Over time decay wins:
+//! the SYNAPSE graph reaches ZERO edges, and `detect_skills_pipeline` silently
+//! no-ops because it needs >= `min_notes_for_detection` (15) notes that already
+//! participate in synapses. Symptom: "skill detection produces no effect" while
+//! `get_intelligence_summary` shows `active_synapses: 0` despite thousands of notes.
+//!
+//! This check counterbalances decay by periodically backfilling synapses from the
+//! notes' STORED embeddings (`backfill_synapses`). It needs no embedding provider —
+//! `backfill_synapses` reads stored embeddings and does vector search via the
+//! GraphStore — so it runs with just the heartbeat's `graph` + `search`. The
+//! backfill self-gates (early-returns when every note already has synapses), so on
+//! a healthy graph this check costs almost nothing; on a depleted one it rebuilds.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tracing::{debug, info, warn};
+
+use crate::heartbeat::{HeartbeatCheck, HeartbeatContext};
+use crate::notes::NoteManager;
+
+/// Notes processed per backfill batch.
+const REPLENISH_BATCH_SIZE: usize = 100;
+/// Max neighbours linked per note when rebuilding.
+const REPLENISH_MAX_NEIGHBORS: usize = 10;
+/// Per-run timeout. A fully-decayed large graph can take minutes to rebuild, so
+/// this must exceed the engine's 5s default (otherwise the rebuild is cancelled
+/// every tick and `last_run` never advances — the same starvation #309 fixed).
+const REPLENISH_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+/// Rebuild synapses that decay has eroded away (every 12 hours).
+pub struct SynapseReplenishCheck;
+
+#[async_trait]
+impl HeartbeatCheck for SynapseReplenishCheck {
+    fn name(&self) -> &str {
+        "synapse_replenish"
+    }
+
+    fn interval(&self) -> Duration {
+        // Twice the 6h decay cadence: frequent enough to keep ahead of pruning
+        // (a 0.75-weight synapse takes days to decay below the 0.05 prune floor),
+        // infrequent enough to keep the heavy rebuild rare.
+        Duration::from_secs(12 * 60 * 60)
+    }
+
+    fn timeout_override(&self) -> Option<Duration> {
+        Some(REPLENISH_TIMEOUT)
+    }
+
+    async fn run(&self, ctx: &HeartbeatContext) -> Result<()> {
+        let Some(search) = ctx.search.clone() else {
+            warn!("SynapseReplenishCheck: no search store available, skipping replenish");
+            return Ok(());
+        };
+
+        // `backfill_synapses` self-gates: it lists only notes that have an embedding
+        // but no synapses, and returns early when there are none. So calling it
+        // unconditionally is cheap on a healthy graph and rebuilds a depleted one.
+        // `min_similarity = 0.0` auto-calibrates the threshold from the existing
+        // weight distribution (falls back to 0.75 when the graph is empty).
+        let nm = NoteManager::new(ctx.graph.clone(), search);
+        let progress = nm
+            .backfill_synapses(REPLENISH_BATCH_SIZE, 0.0, REPLENISH_MAX_NEIGHBORS, None)
+            .await?;
+
+        if progress.synapses_created > 0 || progress.energy_initialized > 0 {
+            info!(
+                "SynapseReplenishCheck: rebuilt {} synapses across {} notes (energy initialized on {})",
+                progress.synapses_created, progress.processed, progress.energy_initialized
+            );
+        } else {
+            debug!("SynapseReplenishCheck: synapse graph healthy, nothing to replenish");
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_synapse_replenish_check_name() {
+        assert_eq!(SynapseReplenishCheck.name(), "synapse_replenish");
+    }
+
+    #[test]
+    fn test_synapse_replenish_check_interval() {
+        assert_eq!(
+            SynapseReplenishCheck.interval(),
+            Duration::from_secs(12 * 3600)
+        );
+    }
+
+    #[test]
+    fn test_synapse_replenish_timeout_override_exceeds_default() {
+        // Must exceed the engine's 5s default, else the rebuild is cancelled every
+        // tick and never persists (the decay-without-replenishment death spiral).
+        let t = SynapseReplenishCheck.timeout_override();
+        assert_eq!(t, Some(Duration::from_secs(600)));
+        assert!(t.unwrap() > Duration::from_secs(5));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1434,11 +1434,16 @@ pub async fn start_server(mut config: Config) -> Result<()> {
             Box::new(GitDriftCheck),
             Box::new(StalenessCheck),
             Box::new(SynapseDecayCheck),
-            Box::new(SynapseReplenishCheck),
             Box::new(ConventionGuardCheck),
             Box::new(MaintenanceCheck),
             Box::new(ConsolidationCheck),
             Box::new(HomeostasisCheck::new()),
+            // MUST run LAST: the engine executes checks in vec order within a tick
+            // (engine.rs:88). SynapseDecayCheck and MaintenanceCheck (deep_maintenance
+            // applies an aggressive 3x decay + prune) both delete synapses; replenish
+            // has to rebuild AFTER them, otherwise at startup — when every check is due —
+            // a fresh rebuild would be wiped by the maintenance prune in the same tick.
+            Box::new(SynapseReplenishCheck),
         ];
 
         let engine = HeartbeatEngine::new(graph, search, emitter, checks);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1421,6 +1421,7 @@ pub async fn start_server(mut config: Config) -> Result<()> {
             consolidation::ConsolidationCheck, convention_guard::ConventionGuardCheck,
             git_drift::GitDriftCheck, homeostasis::HomeostasisCheck, maintenance::MaintenanceCheck,
             staleness::StalenessCheck, synapse_decay::SynapseDecayCheck,
+            synapse_replenish::SynapseReplenishCheck,
         };
         use heartbeat::engine::HeartbeatEngine;
 
@@ -1433,6 +1434,7 @@ pub async fn start_server(mut config: Config) -> Result<()> {
             Box::new(GitDriftCheck),
             Box::new(StalenessCheck),
             Box::new(SynapseDecayCheck),
+            Box::new(SynapseReplenishCheck),
             Box::new(ConventionGuardCheck),
             Box::new(MaintenanceCheck),
             Box::new(ConsolidationCheck),

--- a/src/notes/manager.rs
+++ b/src/notes/manager.rs
@@ -534,9 +534,16 @@ impl NoteManager {
             if content_changed {
                 self.embed_note(id, &note.content).await;
 
-                // Content changed → delete old synapses and re-connect
-                // delete_synapses is best-effort (non-critical for the update)
-                if self.synapse_config.enabled {
+                // Content changed → delete old synapses and re-connect.
+                // CRITICAL: only delete when we can actually RECREATE — i.e. when
+                // an embedding provider is present. `spawn_auto_connect_synapses`
+                // silently returns if `embedding_provider` is None, so without this
+                // guard a content update on a provider-less server would DELETE the
+                // note's synapses and recreate nothing — every edit bleeds the
+                // synapse graph toward zero (breaking skill detection). Better to
+                // keep slightly-stale synapses than to wipe them irrecoverably;
+                // the SynapseReplenishCheck refreshes them from stored embeddings.
+                if self.synapse_config.enabled && self.embedding_provider.is_some() {
                     if let Err(e) = self.neo4j.delete_synapses(id).await {
                         tracing::warn!(
                             note_id = %id,


### PR DESCRIPTION
## Problem
The "run detection" button on the Skills page produces no effect and the system never auto-creates skills. Empirically: thousands of notes exist and are embedded (semantic search works), yet `intelligence_summary` shows `active_synapses: 0` and `detect_skills` returns `InsufficientData` ("0 notes with synapses, minimum 15").

## Root cause: decay with no replenishment
The SYNAPSE graph trends to zero because creation < decay and nothing rebuilds it:
1. **Natural creation** (`spawn_auto_connect_synapses`, on note create/update) requires cosine ≥ `SynapseConfig.min_weight = 0.75` — high, so few edges form between diverse notes.
2. **Decay runs unconditionally** — `SynapseDecayCheck` every 6h (prune-deletes weight < 0.05) plus `deep_maintenance` (which triples the decay rate).
3. **No automatic replenishment** — `backfill_synapses` (which uses a *lower* calibrated threshold ≈0.6 and so creates many edges) was **manual-only**.

→ decay always wins → 0 synapses → `detect_skills_pipeline` silently no-ops (needs ≥15 notes participating in synapses).

This is the structural counterpart to #309: #309 let `deep_maintenance` actually run; this gives decay a replenishment loop so the graph self-sustains.

## Changes
- **`SynapseReplenishCheck`** (new heartbeat check, every 12h, `timeout_override` 10min) — re-runs `backfill_synapses` from notes' **stored embeddings** (`NoteManager::new(graph, search)`; backfill reads stored embeddings + vector-searches via the GraphStore, so **no embedding provider needed**). It self-gates (early-returns when every note already has synapses), so a healthy graph costs ~nothing and a depleted one gets rebuilt. `src/heartbeat/checks/synapse_replenish.rs` (new) + `mod.rs` + `lib.rs` registration.
- **`notes/manager.rs` — defensive**: only `delete_synapses` on content-update when `embedding_provider.is_some()` (the async recreate silently no-ops without a provider). Prevents a *future* provider-less deployment from deleting synapses it can't recreate. (No-op when a provider is present, which is the normal case.)

## Test plan
- [x] `cargo test --lib heartbeat::checks::synapse_replenish` — 3 passed (name, 12h interval, timeout 600s > 5s default)
- [x] `cargo test --lib notes::manager::tests` — 46 passed
- [x] `cargo fmt --check` clean
- [ ] Runtime: after deploy, confirm `active_synapses` stays > 0 across decay cycles and `detect_skills` returns Success without a manual backfill.

## ⚠️ Known residual (needs server logs, not in this PR)
On the live server, a manual `backfill_synapses` created ~170 synapses once (one `detect_skills` read 77 notes/170 synapses → 6 skills), but they did **not persist** across subsequent reads, and `dead_notes_count` (3794) exceeds total `notes` (1787) — suggesting a concurrent pruner and/or a data-integrity issue from the redeploy. This PR makes the graph self-heal structurally; if synapses still don't persist after deploy, the next levers are softening decay (`DEFAULT_PRUNE_THRESHOLD` 0.05→0.02, the `deep_maintenance` 3× multiplier) and/or lowering `min_weight` 0.75→0.6. Recommend grepping the heartbeat logs for which check prunes how many synapses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)