### PR TITLE
fix(metrics): scope neural metrics to the project

### DIFF
--- a/src/neo4j/analytics.rs
+++ b/src/neo4j/analytics.rs
@@ -1465,13 +1465,16 @@ impl Neo4jClient {
             MATCH (p:Project {id: $project_id})-[:CONTAINS]->(f:File)
             OPTIONAL MATCH (n:Note)-[:LINKED_TO]->(f)
             WITH count(DISTINCT n) AS total_notes
-            OPTIONAL MATCH (n1:Note)-[s:SYNAPSE]->(n2:Note) WHERE s.weight >= 0.1
+            OPTIONAL MATCH (n1:Note)-[s:SYNAPSE]->(n2:Note)
+              WHERE n1.project_id = $project_id AND n2.project_id = $project_id AND s.weight >= 0.1
             WITH total_notes, count(s) AS active_synapses, avg(s.weight) AS avg_weight,
                  sum(CASE WHEN s.weight < $weak_threshold THEN 1 ELSE 0 END) AS weak_synapses
-            OPTIONAL MATCH (n:Note) WHERE n.energy IS NOT NULL AND n.energy < 0.05
+            OPTIONAL MATCH (n:Note)
+              WHERE n.project_id = $project_id AND n.energy IS NOT NULL AND n.energy < 0.05
             WITH total_notes, active_synapses, coalesce(avg_weight, 0) AS avg_weight,
                  coalesce(weak_synapses, 0) AS weak_synapses, count(n) AS dead_notes
-            OPTIONAL MATCH (rn:Note) WHERE rn.reactivation_count IS NOT NULL AND rn.reactivation_count > 0
+            OPTIONAL MATCH (rn:Note)
+              WHERE rn.project_id = $project_id AND rn.reactivation_count IS NOT NULL AND rn.reactivation_count > 0
             WITH total_notes, active_synapses, avg_weight, weak_synapses, dead_notes,
                  avg(coalesce(rn.reactivation_count, 0)) AS avg_reactivation
             RETURN active_synapses, avg_weight AS avg_energy,


### PR DESCRIPTION
## Problem
`get_neural_metrics` computed `active_synapses`, `weak_synapses`, `dead_notes` and `avg_reactivation` with **no project filter** — the `SYNAPSE`/`Note` matches ran across **all projects**. So the per-project intelligence dashboard misreported global numbers — e.g. `dead_notes_count` (3794) exceeding the project's own `notes` (1787), and `active_synapses` reflecting every project at once. This is what made the synapse-death diagnosis confusing.

## Fix
Add `project_id` filters to the synapse match (both endpoints), the dead-notes match, and the reactivation match — mirroring `get_synapse_graph`, which already requires `n.project_id = $project_id`. The dashboard now reports the project's real synapse health, which makes it possible to **verify the #310 synapse self-heal per project**.

## Test plan
- [x] `cargo check --lib` clean
- [x] `cargo fmt --check` clean
- [ ] Runtime: `get_intelligence_summary` for a project shows `dead_notes_count <= notes` and per-project `active_synapses`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)