### PR TITLE
fix(synapses): backfill skips archived/isolated notes that blocked synapse creation

### DIFF
--- a/src/neo4j/note.rs
+++ b/src/neo4j/note.rs
@@ -3099,6 +3099,7 @@ impl Neo4jClient {
             r#"
             MATCH (n:Note)
             WHERE n.embedding IS NOT NULL AND NOT (n)-[:SYNAPSE]->()
+              AND n.status IN ['active', 'needs_review']
             RETURN count(n) AS total
             "#,
         );
@@ -3118,6 +3119,7 @@ impl Neo4jClient {
             r#"
             MATCH (n:Note)
             WHERE n.embedding IS NOT NULL AND NOT (n)-[:SYNAPSE]->()
+              AND n.status IN ['active', 'needs_review']
             RETURN n
             ORDER BY n.created_at
             SKIP $offset LIMIT $limit

--- a/src/notes/manager.rs
+++ b/src/notes/manager.rs
@@ -1606,10 +1606,6 @@ impl NoteManager {
                 break;
             }
 
-            // Track how many notes in this batch couldn't be connected —
-            // if ALL of them fail, we've exhausted the connectable notes.
-            let mut batch_connected = 0usize;
-
             for note in &batch {
                 // Check cancellation per-note for responsiveness
                 if let Some(flag) = cancel {
@@ -1693,7 +1689,6 @@ impl NoteManager {
                 match self.neo4j.create_synapses(note.id, &synapse_targets).await {
                     Ok(created) => {
                         synapses_created += created;
-                        batch_connected += 1;
                         // Note now has synapses → will NOT appear in next
                         // query at the same offset. Don't increment skip_offset.
                     }
@@ -1716,12 +1711,14 @@ impl NoteManager {
                 "Synapse backfill: {processed}/{total} notes processed, {synapses_created} synapses created ({errors} errors, {skip_offset} skipped)"
             );
 
-            // If no note in this batch could be connected, all remaining
-            // notes are un-connectable — stop to avoid spinning forever.
-            if batch_connected == 0 {
-                tracing::info!("Synapse backfill: no more connectable notes found, stopping");
-                break;
-            }
+            // NOTE: we deliberately do NOT stop when a whole batch failed to
+            // connect. Un-connectable notes (isolated, or whose only neighbours
+            // are filtered out) are skipped via `skip_offset` and the loop
+            // terminates naturally once the offset exhausts the candidate list
+            // (`batch.is_empty()` above). The old `if batch_connected == 0 break`
+            // stranded connectable notes whenever un-connectable ones clustered
+            // at the front of the (created_at-ordered) list — which is why a
+            // corpus dominated by isolated notes produced ZERO synapses.
         }
 
         let skipped = total.saturating_sub(processed + errors);
@@ -1795,8 +1792,6 @@ impl NoteManager {
             if batch.is_empty() || remaining == 0 {
                 break;
             }
-
-            let mut batch_connected = 0usize;
 
             for decision in &batch {
                 if let Some(flag) = cancel {
@@ -1897,7 +1892,6 @@ impl NoteManager {
                 {
                     Ok(created) => {
                         synapses_created += created;
-                        batch_connected += 1;
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -1918,12 +1912,9 @@ impl NoteManager {
                 "Synapse backfill (decisions): {processed}/{total} processed, {synapses_created} cross-entity synapses ({errors} errors)"
             );
 
-            if batch_connected == 0 {
-                tracing::info!(
-                    "Synapse backfill (decisions): no more connectable decisions, stopping"
-                );
-                break;
-            }
+            // See the note-synapse loop above: do not early-stop on an
+            // all-un-connectable batch; rely on skip_offset/offset exhaustion so
+            // connectable entities after a cluster of isolated ones are reached.
         }
 
         Ok((synapses_created, processed, errors))


### PR DESCRIPTION
## Problem
`backfill_synapses` (and the #310 `SynapseReplenishCheck` that calls it) created **zero synapses** on the real corpus → `detect_skills` always returned `InsufficientData` and the Skills page stayed empty.

## Root cause (confirmed by querying Neo4j directly)
Project has 5023 Note nodes (3291 `archived`, 1727 `active`), 2333 with embeddings, **0 synapses**. The `note_embeddings` vector index is ONLINE and returns neighbours at score 0.96-0.98 — there are **128 valid same-project pairs across ~45 active notes** at score ≥ 0.75. A direct Cypher MERGE of those made `detect_skills` succeed (8 skills). So creation/detection work — backfill just never reached them, because:
1. **`list_notes_needing_synapses` had no status filter** → returned all 2333 embedded-but-unsynapsed notes (dominated by 3291 archived), ordered by `created_at`. But `vector_search_notes` only accepts `status IN ['active','needs_review']` neighbours → archived/isolated notes never connect.
2. **The loop broke early** on the first `batch_connected == 0` batch. With un-connectable notes clustered at the front, it stopped **before** reaching the connectable active notes → 0 created.

## Fix
- Filter `list_notes_needing_synapses` to `status IN ['active','needs_review']` (count + fetch).
- Remove the premature `batch_connected == 0` early-break in both note and decision loops (`skip_offset`/offset-exhaustion already terminates). Drop the now-unused `batch_connected`.

This makes #310's `SynapseReplenishCheck` actually rebuild the graph instead of no-opping.

## Test plan
- [x] `cargo test --lib notes::manager::tests` — 43 passed
- [x] `RUSTFLAGS=-D warnings cargo check --lib` clean; `cargo fmt --check` clean
- [x] Verified live against Neo4j (128 pairs / 45 notes; direct MERGE → detect Success)

## Related
Completes the arc: #309 → #310 → **this** (replenish actually creates synapses). Pairs with frontend #139 (button no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)