### PR TITLE
fix(desktop): migrate rand API to 0.10 (unbreak main after #292)

### DIFF
--- a/desktop/src-tauri/src/setup.rs
+++ b/desktop/src-tauri/src/setup.rs
@@ -5,7 +5,7 @@
 //! - Generate a config.yaml from wizard input
 //! - Detect if Claude Code CLI is installed
 
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -330,10 +330,10 @@ fn dirs_next_config_dir() -> Option<PathBuf> {
 
 /// Generate a random alphanumeric string of the given length.
 fn random_secret(len: usize) -> String {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     (0..len)
         .map(|_| {
-            let idx = rng.gen_range(0..62);
+            let idx = rng.random_range(0..62);
             match idx {
                 0..=9 => (b'0' + idx) as char,
                 10..=35 => (b'a' + idx - 10) as char,


### PR DESCRIPTION
## Problem
PR #292 bumped `rand` 0.8 → 0.10. The desktop (Tauri) crate is **not built in the standard CI workflow**, so rand's breaking API changes went undetected and **broke `main`** (`cargo check --workspace` fails to compile `project-orchestrator-desktop`).

## Fix
`desktop/src-tauri/src/setup.rs`:
- `rand::thread_rng()` → `rand::rng()`
- `rng.gen_range(..)` → `rng.random_range(..)`
- `use rand::Rng` → `use rand::RngExt` (the `random_range` method moved from `Rng` to the new `RngExt` extension trait in rand 0.10)

## Verification
`cargo check --workspace` passes locally with rustc 1.96 (rand 0.10 / sysinfo 0.39 require ≥1.95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)