### PR TITLE
fix(security): patch rand (GHSA-cq8v-f236-94qc) — alerts #18, #26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
  "memmap2",
  "num-traits",
  "num_cpus",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_distr",
  "rayon",
  "safetensors 0.4.5",
@@ -3108,7 +3108,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_distr",
  "zerocopy",
 ]
@@ -3197,7 +3197,7 @@ dependencies = [
  "libc",
  "log",
  "native-tls",
- "rand 0.9.2",
+ "rand 0.9.3",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -6078,7 +6078,7 @@ dependencies = [
  "pasetors",
  "petgraph",
  "rag-umap",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "rayon",
  "regex",
@@ -6138,7 +6138,7 @@ dependencies = [
  "futures-util",
  "objc",
  "project-orchestrator",
- "rand 0.10.0",
+ "rand 0.10.1",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -6241,7 +6241,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -6329,9 +6329,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6339,9 +6339,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -6418,7 +6418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -6475,7 +6475,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -8309,7 +8309,7 @@ dependencies = [
  "futures-util",
  "http",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "serde",
  "serde_json",
@@ -8594,7 +8594,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rayon",
  "rayon-cond 0.4.0",
  "regex",
@@ -9226,7 +9226,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -9245,7 +9245,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
 ]


### PR DESCRIPTION
Resolves Dependabot alerts for `rand` unsoundness (GHSA-cq8v-f236-94qc).

## Fixed (Cargo.lock, lock-only patch bumps)
- **#26** — `rand` 0.9.2 → **0.9.3** (vuln range `>=0.9.0,<0.9.3`)
- **#18** — `rand` 0.10.0 → **0.10.1** (vuln `==0.10.0`)

Both are patch bumps with identical dependency sets; checksums pulled from crates.io. Surgical lock edit — no other packages touched.

## Not fixable here
- **#29** — `rand` 0.7.3 (range `>=0.7.0,<0.8.6`): pulled transitively via `phf_generator 0.8` (tauri build-dependencies of the `desktop` crate). No fix exists in the 0.7 line; requires an upstream tauri/phf bump. **Low severity, build-time only.** Recommend dismissing as "no fix available" or tracking upstream.

## ⚠️ Separate pre-existing issue spotted
The committed `Cargo.lock` is **out of sync with `Cargo.toml`**: lock has `tree-sitter-go 0.25.0`, `tree-sitter-scala 0.26.0`, `sha2 0.11.0` but `Cargo.toml` constrains `0.23` / `0.24` / `0.10`. Any `cargo build` auto-downgrades these. Dependabot PRs #295/#297/#298 appear to have updated the lock without bumping `Cargo.toml`, so those bumps are not actually in effect. Worth a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)