### PR TITLE
docs(release): bump download links to v0.0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.13_aarch64.dmg"><img src="https://img.shields.io/badge/Download_for_macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS" height="40"></a>
+  <a href="https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_aarch64.dmg"><img src="https://img.shields.io/badge/Download_for_macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS" height="40"></a>
   &nbsp;&nbsp;
-  <a href="https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.13_x64-setup.exe"><img src="https://img.shields.io/badge/Download_for_Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" height="40"></a>
+  <a href="https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_x64-setup.exe"><img src="https://img.shields.io/badge/Download_for_Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" height="40"></a>
   &nbsp;&nbsp;
-  <a href="https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.13_amd64.AppImage"><img src="https://img.shields.io/badge/Download_for_Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download for Linux" height="40"></a>
+  <a href="https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_amd64.AppImage"><img src="https://img.shields.io/badge/Download_for_Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download for Linux" height="40"></a>
 </p>
 
 <p align="center">
@@ -66,13 +66,13 @@ Download the desktop app for your platform:
 
 | Platform | Download | Type |
 |----------|----------|------|
-| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.13_aarch64.dmg) | M1/M2/M3/M4 |
-| **macOS** (Intel) | [Download .dmg](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.13_x64.dmg) | Intel Mac |
-| **Windows** (64-bit) | [Download .exe](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.13_x64-setup.exe) | Installer |
-| **Windows** (64-bit MSI) | [Download .msi](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.13_x64_en-US.msi) | MSI |
-| **Linux** (64-bit) | [Download .AppImage](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.13_amd64.AppImage) | Universal |
-| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator_0.0.13-1_amd64.deb) | apt/dpkg |
-| **Linux** (Fedora/RHEL) | [Download .rpm](https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator-0.0.13-1.x86_64.rpm) | dnf/rpm |
+| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_aarch64.dmg) | M1/M2/M3/M4 |
+| **macOS** (Intel) | [Download .dmg](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_x64.dmg) | Intel Mac |
+| **Windows** (64-bit) | [Download .exe](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_x64-setup.exe) | Installer |
+| **Windows** (64-bit MSI) | [Download .msi](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_x64_en-US.msi) | MSI |
+| **Linux** (64-bit) | [Download .AppImage](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_amd64.AppImage) | Universal |
+| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator_0.0.14-1_amd64.deb) | apt/dpkg |
+| **Linux** (Fedora/RHEL) | [Download .rpm](https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator-0.0.14-1.x86_64.rpm) | dnf/rpm |
 
 > All releases are available on the [Releases page](https://github.com/this-rs/project-orchestrator/releases/latest).
 
@@ -98,7 +98,7 @@ Options:
 
 ```bash
 # Install a specific version
-curl -fsSL https://…/install.sh | sh -s -- --version 0.0.13
+curl -fsSL https://…/install.sh | sh -s -- --version 0.0.14
 
 # Install without the embedded frontend (lighter)
 curl -fsSL https://…/install.sh | sh -s -- --no-frontend
@@ -141,8 +141,8 @@ docker compose up -d
 
 ```bash
 # Download and install the .deb package
-curl -LO https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator_0.0.13-1_amd64.deb
-sudo dpkg -i project-orchestrator_0.0.13-1_amd64.deb
+curl -LO https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator_0.0.14-1_amd64.deb
+sudo dpkg -i project-orchestrator_0.0.14-1_amd64.deb
 
 # Start the service
 sudo systemctl enable --now project-orchestrator
@@ -154,8 +154,8 @@ sudo systemctl enable --now project-orchestrator
 
 ```bash
 # Download and install the .rpm package
-curl -LO https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator-0.0.13-1.x86_64.rpm
-sudo rpm -i project-orchestrator-0.0.13-1.x86_64.rpm
+curl -LO https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator-0.0.14-1.x86_64.rpm
+sudo rpm -i project-orchestrator-0.0.14-1.x86_64.rpm
 ```
 
 ---


### PR DESCRIPTION
Bumps README download links (badges, install table, deb/rpm commands) from **0.0.13 → 0.0.14** ahead of the v0.0.14 release.

- Asset filenames carry the version (`Project.Orchestrator_0.0.14_*`), URLs use the `releases/latest/download/` redirect.
- No manifest bump: `release.yml` injects the version from the git tag (`Cargo.toml` sed + frontend `npm pkg set version`).
- Homebrew formula untouched (placeholders auto-filled by release CI).

Part of the v0.0.14 release (tag triggers the build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)