### PR TITLE
fix(desktop): Linux app fails to launch (webkitgtk DMABUF)

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -118,6 +118,19 @@ fn webview_log(level: String, message: String) {
 }
 
 fn main() {
+    // Linux launch fix (2026-06-02) — webkitgtk ≥ 2.42 ships a DMABUF renderer
+    // that crashes or shows a blank window at startup on many Linux setups
+    // (Wayland, NVIDIA proprietary, several recent Intel/Mesa stacks). This is
+    // the most common cause of "the Linux desktop app doesn't launch". Disable
+    // it BEFORE the webview initializes. No-op on macOS/Windows; respects an
+    // explicit user override if already set in the environment.
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+    }
+
     // Initialize tracing
     tracing_subscriber::registry()
         .with(


### PR DESCRIPTION
## Problem
The Linux desktop build produces an app that **doesn't launch**.

## Cause
`webkitgtk >= 2.42` ships a DMABUF renderer that crashes / shows a blank window at startup on many Linux configs (Wayland, NVIDIA proprietary, recent Intel/Mesa). This is the single most common cause of Tauri-on-Linux launch failures. The app never set the standard workaround.

## Fix
Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` at the very start of `main()`, before the webview initializes.
- `#[cfg(target_os = "linux")]` — **no-op on macOS/Windows**.
- Respects an explicit user override (only sets if unset).
- Edition 2021 → `set_var` is safe.

## Validation
Compiles; logic is trivial. **Runtime launch must be confirmed on a Linux machine** (or the v0.0.14 AppImage) since it can't be exercised from macOS CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)