### PR TITLE
ci(release): build Linux arm64 desktop bundle (AppImage + .deb)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -535,6 +535,17 @@ jobs:
             artifact_os: linux
             artifact_arch: x86_64
 
+          # Linux arm64 desktop bundle (AppImage + .deb). Built natively on a
+          # GitHub-hosted ARM runner — produces Project.Orchestrator_*_aarch64.AppImage
+          # and the arm64 .deb so ARM Linux machines (e.g. DGX Spark / aarch64)
+          # get a runnable desktop app instead of the x86_64 AppImage they can't
+          # execute (GNOME falls back to "mount as disk image" → nothing happens).
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            tauri_target: aarch64-unknown-linux-gnu
+            artifact_os: linux
+            artifact_arch: arm64
+
           - target: x86_64-pc-windows-msvc
             runner: windows-latest
             tauri_target: x86_64-pc-windows-msvc


### PR DESCRIPTION
## Problem
On aarch64 Linux (DGX Spark), the only Linux desktop bundle is **x86_64** (`Project.Orchestrator_*_amd64.AppImage`). It can't execute on ARM → GNOME offers to *mount it as a disk image* and nothing happens → **can't install the app**.

The `build-tauri` matrix had: macOS arm64+x86_64, Linux **x86_64 only**, Windows. (`build-backend` and `package-deb` already build arm64 for the CLI/server — only the **desktop GUI** was missing arm64.)

## Fix
Add `aarch64-unknown-linux-gnu` to the `build-tauri` matrix on a native **`ubuntu-24.04-arm`** runner → produces `Project.Orchestrator_*_aarch64.AppImage` + arm64 `.deb`.

No other changes needed — steps are parameterized by `matrix.{target,artifact_os,artifact_arch}`:
- webkit deps install gated on `runner.os == 'Linux'` ✓
- `mcp_server` downloaded per-arch (build-backend already emits arm64) ✓
- release job collects `tauri-*` → new bundles attached automatically ✓

Ships in the next tag (v0.0.14 is already published). Linux arm64 launch to be confirmed on the DGX once built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)