### PR TITLE
docs(readme): Linux arm64 downloads + fix Linux button

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_aarch64.dmg"><img src="https://img.shields.io/badge/Download_for_macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS" height="40"></a>
+  <a href="https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.16_aarch64.dmg"><img src="https://img.shields.io/badge/Download_for_macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS" height="40"></a>
   &nbsp;&nbsp;
-  <a href="https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_x64-setup.exe"><img src="https://img.shields.io/badge/Download_for_Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" height="40"></a>
+  <a href="https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.16_x64-setup.exe"><img src="https://img.shields.io/badge/Download_for_Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" height="40"></a>
   &nbsp;&nbsp;
-  <a href="https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_amd64.AppImage"><img src="https://img.shields.io/badge/Download_for_Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download for Linux" height="40"></a>
+  <a href="#desktop-app"><img src="https://img.shields.io/badge/Download_for_Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download for Linux" height="40"></a>
 </p>
 
 <p align="center">
@@ -66,13 +66,16 @@ Download the desktop app for your platform:
 
 | Platform | Download | Type |
 |----------|----------|------|
-| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_aarch64.dmg) | M1/M2/M3/M4 |
-| **macOS** (Intel) | [Download .dmg](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_x64.dmg) | Intel Mac |
-| **Windows** (64-bit) | [Download .exe](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_x64-setup.exe) | Installer |
-| **Windows** (64-bit MSI) | [Download .msi](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_x64_en-US.msi) | MSI |
-| **Linux** (64-bit) | [Download .AppImage](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_amd64.AppImage) | Universal |
-| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator_0.0.14-1_amd64.deb) | apt/dpkg |
-| **Linux** (Fedora/RHEL) | [Download .rpm](https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator-0.0.14-1.x86_64.rpm) | dnf/rpm |
+| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.16_aarch64.dmg) | M1/M2/M3/M4 |
+| **macOS** (Intel) | [Download .dmg](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.16_x64.dmg) | Intel Mac |
+| **Windows** (64-bit) | [Download .exe](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.16_x64-setup.exe) | Installer |
+| **Windows** (64-bit MSI) | [Download .msi](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.16_x64_en-US.msi) | MSI |
+| **Linux** (x86_64 AppImage) | [Download .AppImage](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.16_amd64.AppImage) | Intel/AMD |
+| **Linux** (arm64 AppImage) | [Download .AppImage](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.16_aarch64.AppImage) | ARM64 (DGX Spark, Ampere, RPi…) |
+| **Linux** (Debian/Ubuntu x86_64) | [Download .deb](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.16_amd64.deb) | apt/dpkg |
+| **Linux** (Debian/Ubuntu arm64) | [Download .deb](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.16_arm64.deb) | apt/dpkg |
+| **Linux** (Fedora/RHEL x86_64) | [Download .rpm](https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator-0.0.16-1.x86_64.rpm) | dnf/rpm |
+| **Linux** (Fedora/RHEL arm64) | [Download .rpm](https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator-0.0.16-1.aarch64.rpm) | dnf/rpm |
 
 > All releases are available on the [Releases page](https://github.com/this-rs/project-orchestrator/releases/latest).
 
@@ -98,7 +101,7 @@ Options:
 
 ```bash
 # Install a specific version
-curl -fsSL https://…/install.sh | sh -s -- --version 0.0.14
+curl -fsSL https://…/install.sh | sh -s -- --version 0.0.16
 
 # Install without the embedded frontend (lighter)
 curl -fsSL https://…/install.sh | sh -s -- --no-frontend
@@ -141,8 +144,8 @@ docker compose up -d
 
 ```bash
 # Download and install the .deb package
-curl -LO https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator_0.0.14-1_amd64.deb
-sudo dpkg -i project-orchestrator_0.0.14-1_amd64.deb
+curl -LO https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator_0.0.16-1_amd64.deb
+sudo dpkg -i project-orchestrator_0.0.16-1_amd64.deb
 
 # Start the service
 sudo systemctl enable --now project-orchestrator
@@ -154,8 +157,8 @@ sudo systemctl enable --now project-orchestrator
 
 ```bash
 # Download and install the .rpm package
-curl -LO https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator-0.0.14-1.x86_64.rpm
-sudo rpm -i project-orchestrator-0.0.14-1.x86_64.rpm
+curl -LO https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator-0.0.16-1.x86_64.rpm
+sudo rpm -i project-orchestrator-0.0.16-1.x86_64.rpm
 ```
 
 ---


### PR DESCRIPTION
The **Download for Linux** button pointed directly at the **x86_64** `_amd64.AppImage`. On aarch64 Linux (DGX Spark) that binary can't execute → GNOME offers to *mount it as a disk image* → nothing launches.

- Linux badge → now links to the **#desktop-app** options table (pick your arch) instead of forcing amd64.
- Table now lists **x86_64 AND arm64** for AppImage + `.deb` (+ rpm), using the desktop bundles.
- Links bumped to **0.0.15** — the release that ships the arm64 desktop bundle (PR #324).

⚠️ **Do not merge until v0.0.15 is published** and the exact arm64 asset names are confirmed (`_aarch64.AppImage`, `_arm64.deb`) — `releases/latest/download/` 404s otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)