### PR TITLE
fix(release): install xdg-utils on ARM runner (Tauri AppImage bundling)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -638,7 +638,10 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev
+          # xdg-utils (provides /usr/bin/xdg-open) + desktop-file-utils are preinstalled on
+          # the x86_64 ubuntu-latest image but NOT on ubuntu-24.04-arm — the Tauri AppImage
+          # bundler hard-fails without xdg-open ("xdg-open binary not found"). Install explicitly.
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev xdg-utils desktop-file-utils
 
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version "^2"


### PR DESCRIPTION
v0.0.15's Tauri arm64 job failed: `xdg-open binary not found /usr/bin/xdg-open`. `xdg-utils` is preinstalled on x86_64 ubuntu-latest but not on `ubuntu-24.04-arm`; Tauri's AppImage bundler requires it. Adds `xdg-utils desktop-file-utils` to the Linux deps. Ships in v0.0.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)