### PR TITLE
fix(release): arm64 Linux desktop ships as .deb/.rpm (skip AppImage)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -545,6 +545,11 @@ jobs:
             tauri_target: aarch64-unknown-linux-gnu
             artifact_os: linux
             artifact_arch: arm64
+            # AppImage bundling is broken on the ubuntu-24.04-arm runner
+            # (linuxdeploy/appimagetool fail to run even with FUSE workarounds).
+            # .deb + .rpm build fine and are the cleaner install path on ARM,
+            # so restrict the arm64 desktop bundle to those.
+            bundles: deb,rpm
 
           - target: x86_64-pc-windows-msvc
             runner: windows-latest
@@ -824,7 +829,7 @@ jobs:
           # Windows signing
           TAURI_WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
           TAURI_WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
-        run: cargo tauri build --target ${{ matrix.tauri_target }}
+        run: cargo tauri build --target ${{ matrix.tauri_target }} ${{ matrix.bundles && format('--bundles {0}', matrix.bundles) || '' }}
 
       # Free disk space after Tauri build completes.
       # The cargo build output (deps/, build/, .fingerprint/, incremental/) can

--- a/README.md
+++ b/README.md
@@ -71,9 +71,8 @@ Download the desktop app for your platform:
 | **Windows** (64-bit) | [Download .exe](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_x64-setup.exe) | Installer |
 | **Windows** (64-bit MSI) | [Download .msi](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_x64_en-US.msi) | MSI |
 | **Linux** (x86_64 AppImage) | [Download .AppImage](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_amd64.AppImage) | Intel/AMD |
-| **Linux** (arm64 AppImage) | [Download .AppImage](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_aarch64.AppImage) | ARM64 (DGX Spark, Ampere, RPi…) |
 | **Linux** (Debian/Ubuntu x86_64) | [Download .deb](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_amd64.deb) | apt/dpkg |
-| **Linux** (Debian/Ubuntu arm64) | [Download .deb](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_arm64.deb) | apt/dpkg |
+| **Linux** (Debian/Ubuntu **arm64**) | [Download .deb](https://github.com/this-rs/project-orchestrator/releases/latest/download/Project.Orchestrator_0.0.14_arm64.deb) | apt/dpkg — ARM64 (DGX Spark, Ampere, RPi…) |
 | **Linux** (Fedora/RHEL x86_64) | [Download .rpm](https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator-0.0.14-1.x86_64.rpm) | dnf/rpm |
 | **Linux** (Fedora/RHEL arm64) | [Download .rpm](https://github.com/this-rs/project-orchestrator/releases/latest/download/project-orchestrator-0.0.14-1.aarch64.rpm) | dnf/rpm |
 


### PR DESCRIPTION
Third arm64 desktop iteration — pragmatic exit. The arm64 **.deb + .rpm build successfully** on ubuntu-24.04-arm; only **AppImage** fails (linuxdeploy won't run, even after #326 xdg-utils + #328 APPIMAGE_EXTRACT_AND_RUN). Since the job exits on the AppImage error, the working .deb never gets uploaded.

Restrict the arm64 desktop bundle to `--bundles deb,rpm` → job succeeds → arm64 `.deb`/`.rpm` publish. README drops the (broken) arm64 AppImage row and points ARM64 users (DGX Spark) to the arm64 **.deb** — the cleaner install path anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)