### PR TITLE
R* Wave 1 + chat/overview performance fixes

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# Pin the toolchain so the Homebrew cargo (rustc 1.93) shadowing rustup can't
+# silently drive dependency resolution. Observed 2026-06-10: the 1.93 MSRV-aware
+# resolver DOWNGRADED Cargo.lock (async-nats 0.49→0.47, …) because sysinfo@0.39.3
+# requires rustc ≥1.95 — builds stopped being reproducible across shells.
+# With this file, rustup-shimmed cargo always selects 1.95.0; the Homebrew cargo
+# ignores it, so prefer `~/.cargo/bin/cargo` first in PATH.
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]

--- a/src/api/graph_types.rs
+++ b/src/api/graph_types.rs
@@ -1034,13 +1034,14 @@ pub async fn build_intelligence_summary(
         lang_stats_res,
         communities_res,
         hotspots_res,
-        health_res,
+        orphan_count_res,
         notes_res,
         stale_res,
-        co_change_res,
+        co_change_count_res,
         neural_res,
         skills_all_res,
         protocols_res,
+        protocol_st_res,
         pm_graph_res,
         chat_graph_res,
     ) = tokio::join!(
@@ -1048,13 +1049,18 @@ pub async fn build_intelligence_summary(
         neo4j.get_language_stats_for_project(pid),
         neo4j.get_project_communities(pid),
         neo4j.get_top_hotspots(pid, 5),
-        neo4j.get_code_health_report(pid, 200),
+        // Lightweight orphan count — avoids the full health report (and its
+        // PageRank/risk distribution fitting) just to read one number.
+        neo4j.count_orphan_files(pid),
         neo4j.list_notes(Some(pid), None, &note_filters),
         neo4j.get_notes_needing_review(Some(pid)),
-        neo4j.get_co_change_graph(pid, 1, 100_000),
+        // Count co-change pairs instead of pulling up to 100k rows to .len().
+        neo4j.count_co_change_pairs(pid, 1),
         neo4j.get_neural_metrics(pid),
         neo4j.list_skills(pid, None, 1000, 0),
         neo4j.list_protocols(pid, None, 10_000, 0),
+        // Single aggregate replaces the per-protocol states/transitions N+1.
+        neo4j.count_protocol_states_transitions(pid),
         neo4j.get_pm_graph_data(pid, 10_000),
         neo4j.get_chat_graph_data(pid, 100),
     );
@@ -1065,7 +1071,9 @@ pub async fn build_intelligence_summary(
     let function_count: usize = lang_stats.iter().map(|l| l.file_count).sum();
     let communities_list = communities_res.unwrap_or_default();
     let hotspots = hotspots_res.unwrap_or_default();
-    let health = health_res.ok();
+    // True orphan count (the previous full-health path capped the displayed
+    // list at 20; this is the real total).
+    let orphan_count = orphan_count_res.unwrap_or(0) as usize;
 
     let code = CodeLayerSummary {
         files: file_count,
@@ -1078,7 +1086,7 @@ pub async fn build_intelligence_summary(
                 churn_score: h.churn_score,
             })
             .collect(),
-        orphans: health.as_ref().map(|h| h.orphan_files.len()).unwrap_or(0),
+        orphans: orphan_count,
     };
 
     // === Knowledge layer ===
@@ -1100,10 +1108,8 @@ pub async fn build_intelligence_summary(
     };
 
     // === Fabric layer ===
-    let co_changes = co_change_res.unwrap_or_default();
-
     let fabric = FabricLayerSummary {
-        co_changed_pairs: co_changes.len(),
+        co_changed_pairs: co_change_count_res.unwrap_or(0) as usize,
     };
 
     // === Neural layer ===
@@ -1153,17 +1159,11 @@ pub async fn build_intelligence_summary(
     // === Behavioral layer (Protocol Federation) ===
     let (all_protocols, _protocols_total) = protocols_res.unwrap_or((vec![], 0));
 
-    // Count states and transitions across all protocols (fire in parallel)
-    let mut total_states = 0usize;
-    let mut total_transitions = 0usize;
-    for proto in &all_protocols {
-        let (states_res, transitions_res) = tokio::join!(
-            neo4j.get_protocol_states(proto.id),
-            neo4j.get_protocol_transitions(proto.id),
-        );
-        total_states += states_res.map(|s| s.len()).unwrap_or(0);
-        total_transitions += transitions_res.map(|t| t.len()).unwrap_or(0);
-    }
+    // States/transitions totals come from a single aggregate query (fired in the
+    // parallel join above), replacing the previous per-protocol N+1.
+    let (total_states, total_transitions) = protocol_st_res
+        .map(|(s, t)| (s as usize, t as usize))
+        .unwrap_or((0, 0));
 
     let system_count = all_protocols
         .iter()

--- a/src/neo4j/analytics.rs
+++ b/src/neo4j/analytics.rs
@@ -265,6 +265,34 @@ impl Neo4jClient {
         })
     }
 
+    /// Count orphan files for a project (lightweight — no full health report).
+    ///
+    /// Same orphan definition as [`Self::get_code_health_report`]: a File with
+    /// no IMPORTS in either direction and no contained Function. Unlike the
+    /// health report (which LIMITs the orphan list to 20 for display), this
+    /// returns the TRUE total count. Used by the real-time project overview to
+    /// avoid running the full health report — including its expensive PageRank
+    /// and risk-score distribution fitting — just to read one number.
+    pub async fn count_orphan_files(&self, project_id: Uuid) -> Result<i64> {
+        let q = query(
+            r#"
+            MATCH (p:Project {id: $pid})-[:CONTAINS]->(f:File)
+            WHERE NOT EXISTS { (f)-[:IMPORTS]->() }
+              AND NOT EXISTS { ()-[:IMPORTS]->(f) }
+              AND NOT EXISTS { (f)-[:CONTAINS]->(:Function) }
+            RETURN count(f) AS cnt
+            "#,
+        )
+        .param("pid", project_id.to_string());
+
+        let mut result = self.graph.execute(q).await?;
+        if let Some(row) = result.next().await? {
+            Ok(row.get::<i64>("cnt")?)
+        } else {
+            Ok(0)
+        }
+    }
+
     /// WorldModel prediction accuracy (biomimicry T7):
     /// For each of the last N sessions, compute what files the agent discussed,
     /// then check if those files were predictable from the CO_CHANGED graph

--- a/src/neo4j/chat.rs
+++ b/src/neo4j/chat.rs
@@ -810,8 +810,15 @@ impl Neo4jClient {
         offset: i64,
         limit: i64,
     ) -> Result<Vec<ChatEventRecord>> {
+        // Match events by the session_id property (backed by the composite
+        // (session_id, seq) index) rather than expanding the HAS_EVENT
+        // relationship. With the composite index the planner seeks to the
+        // session and walks seq in order, returning after LIMIT — instead of
+        // gathering every event of the conversation and sorting in memory.
+        // Equivalent result: every ChatEvent is created with session_id set to
+        // its owning session (see store_chat_events).
         let q = query(
-            "MATCH (s:ChatSession {id: $session_id})-[:HAS_EVENT]->(e:ChatEvent)
+            "MATCH (e:ChatEvent {session_id: $session_id})
              RETURN e
              ORDER BY e.seq ASC
              SKIP $offset
@@ -834,8 +841,10 @@ impl Neo4jClient {
 
     /// Count total chat events for a session.
     pub async fn count_chat_events(&self, session_id: Uuid) -> Result<i64> {
+        // Count via the session_id property (index-backed) instead of expanding
+        // the HAS_EVENT relationship — same result, no relationship walk.
         let q = query(
-            "MATCH (s:ChatSession {id: $session_id})-[:HAS_EVENT]->(e:ChatEvent)
+            "MATCH (e:ChatEvent {session_id: $session_id})
              RETURN count(e) AS cnt",
         )
         .param("session_id", session_id.to_string());

--- a/src/neo4j/client.rs
+++ b/src/neo4j/client.rs
@@ -309,6 +309,12 @@ impl Neo4jClient {
             "CREATE INDEX chat_event_session IF NOT EXISTS FOR (e:ChatEvent) ON (e.session_id)",
             "CREATE INDEX chat_event_type IF NOT EXISTS FOR (e:ChatEvent) ON (e.event_type)",
             "CREATE INDEX chat_event_seq IF NOT EXISTS FOR (e:ChatEvent) ON (e.seq)",
+            // Composite (session_id, seq) — opening a conversation pages events
+            // with `WHERE e.session_id = $sid RETURN e ORDER BY e.seq ASC SKIP/LIMIT`.
+            // This composite lets the planner seek to the session and walk seq in
+            // order (index-backed ORDER BY + LIMIT), instead of gathering every
+            // event of the conversation via HAS_EVENT and sorting in memory.
+            "CREATE INDEX chat_event_session_seq IF NOT EXISTS FOR (e:ChatEvent) ON (e.session_id, e.seq)",
             // ChatSession indexes — queried by project_slug, workspace_slug, cli_session_id
             "CREATE INDEX chat_session_project IF NOT EXISTS FOR (s:ChatSession) ON (s.project_slug)",
             "CREATE INDEX chat_session_workspace IF NOT EXISTS FOR (s:ChatSession) ON (s.workspace_slug)",

--- a/src/neo4j/client.rs
+++ b/src/neo4j/client.rs
@@ -315,6 +315,18 @@ impl Neo4jClient {
             "CREATE INDEX chat_session_cli IF NOT EXISTS FOR (s:ChatSession) ON (s.cli_session_id)",
             // ChatSession composite index for DISCUSSED relation queries
             "CREATE INDEX chat_session_project_id IF NOT EXISTS FOR (s:ChatSession) ON (s.project_slug, s.id)",
+            // ChatSession ordering indexes — the conversation list does
+            // `ORDER BY s.updated_at DESC SKIP/LIMIT`. Without a range index on
+            // updated_at, Neo4j scans and sorts EVERY ChatSession on each list
+            // load (cost grows with total conversation count, not page size).
+            // A range index lets the planner walk the index in reverse and stop
+            // after LIMIT rows. The composite (project_slug, updated_at) covers
+            // the project-filtered list in a single index seek + ordered scan.
+            "CREATE INDEX chat_session_updated IF NOT EXISTS FOR (s:ChatSession) ON (s.updated_at)",
+            "CREATE INDEX chat_session_project_updated IF NOT EXISTS FOR (s:ChatSession) ON (s.project_slug, s.updated_at)",
+            // ChatSession conversation_id index — search_messages resolves
+            // Meilisearch hits back to sessions by conversation_id.
+            "CREATE INDEX chat_session_conversation IF NOT EXISTS FOR (s:ChatSession) ON (s.conversation_id)",
             // ProtocolRun indexes
             "CREATE INDEX protocol_run_protocol IF NOT EXISTS FOR (r:ProtocolRun) ON (r.protocol_id)",
             "CREATE INDEX protocol_run_status IF NOT EXISTS FOR (r:ProtocolRun) ON (r.status)",

--- a/src/neo4j/commit.rs
+++ b/src/neo4j/commit.rs
@@ -581,6 +581,33 @@ impl Neo4jClient {
         Ok(pairs)
     }
 
+    /// Count CO_CHANGED pairs for a project (lightweight — no row transfer).
+    ///
+    /// Same dedup semantics as [`Self::get_co_change_graph`] (`f1.path < f2.path`
+    /// collapses the bidirectional relationship to one pair). Used by the
+    /// real-time project overview, which previously pulled up to 100k pairs only
+    /// to call `.len()` on them.
+    pub async fn count_co_change_pairs(&self, project_id: Uuid, min_count: i64) -> Result<i64> {
+        let q = query(
+            r#"
+            MATCH (f1:File)-[r:CO_CHANGED]-(f2:File)
+            WHERE r.project_id = $project_id
+              AND r.count >= $min_count
+              AND f1.path < f2.path
+            RETURN count(*) AS cnt
+            "#,
+        )
+        .param("project_id", project_id.to_string())
+        .param("min_count", min_count);
+
+        let mut result = self.graph.execute(q).await?;
+        if let Some(row) = result.next().await? {
+            Ok(row.get::<i64>("cnt")?)
+        } else {
+            Ok(0)
+        }
+    }
+
     /// Get files that co-change with a given file (bidirectional).
     pub async fn get_file_co_changers(
         &self,

--- a/src/neo4j/decision.rs
+++ b/src/neo4j/decision.rs
@@ -2,8 +2,10 @@
 
 use super::client::Neo4jClient;
 use super::models::*;
+use crate::notes::models::EntityType;
 use anyhow::Result;
 use neo4rs::query;
+use std::str::FromStr;
 use uuid::Uuid;
 
 impl Neo4jClient {
@@ -493,8 +495,22 @@ impl Neo4jClient {
 
     /// Create an AFFECTS relation from a Decision to any entity in the graph.
     ///
-    /// The entity is matched by a generic `{id: $entity_id}` or `{path: $entity_id}`
-    /// (for File nodes). The `impact_description` is optional free-text.
+    /// `entity_type` is parsed via [`EntityType::from_str`] so callers may pass
+    /// the snake_case MCP convention (`"file"`, `"workspace_milestone"`) or the
+    /// PascalCase Neo4j label form (`"File"`, `"WorkspaceMilestone"`) —
+    /// internally we always use the canonical [`EntityType::neo4j_label`] to
+    /// build the Cypher.
+    ///
+    /// The entity is matched by [`EntityType::match_property`] (`path` for
+    /// `File`, `hash` for `Commit`, `id` for everything else). For `File`
+    /// targets, a relative `entity_id` (not starting with `/`) is matched via
+    /// `ENDS WITH` against the stored absolute path, preserving the previous
+    /// behaviour for convenience.
+    ///
+    /// Returns `Err` if `entity_type` is not a recognized variant, or if the
+    /// Decision and entity could not both be matched in the graph (previously
+    /// this case was a silent no-op which made the AFFECTS edge an
+    /// unverifiable claim — see the R\* RFC `19b89465`).
     pub async fn add_decision_affects(
         &self,
         decision_id: Uuid,
@@ -502,29 +518,33 @@ impl Neo4jClient {
         entity_id: &str,
         impact_description: Option<&str>,
     ) -> Result<()> {
-        let cypher = if entity_type == "File" && !entity_id.starts_with('/') {
-            // Relative path: use ENDS WITH to match against full absolute paths
+        let etype = EntityType::from_str(entity_type)
+            .map_err(|e| anyhow::anyhow!("add_decision_affects: invalid entity_type: {e}"))?;
+        let label = etype.neo4j_label();
+        let match_field = etype.match_property();
+
+        let cypher = if matches!(etype, EntityType::File) && !entity_id.starts_with('/') {
+            // Relative path: match against full absolute paths via ENDS WITH.
             format!(
                 r#"
                 MATCH (d:Decision {{id: $did}})
-                MATCH (e:{} ) WHERE e.path ENDS WITH $eid
+                MATCH (e:{label}) WHERE e.path ENDS WITH $eid
                 MERGE (d)-[r:AFFECTS]->(e)
                 SET r.impact_description = $desc,
                     r.created_at = datetime()
+                RETURN d.id AS did, e.path AS matched
                 "#,
-                entity_type
             )
         } else {
-            let match_field = if entity_type == "File" { "path" } else { "id" };
             format!(
                 r#"
                 MATCH (d:Decision {{id: $did}})
-                MATCH (e:{} {{{}: $eid}})
+                MATCH (e:{label} {{{match_field}: $eid}})
                 MERGE (d)-[r:AFFECTS]->(e)
                 SET r.impact_description = $desc,
                     r.created_at = datetime()
+                RETURN d.id AS did, e.{match_field} AS matched
                 "#,
-                entity_type, match_field
             )
         };
 
@@ -533,33 +553,51 @@ impl Neo4jClient {
             .param("eid", entity_id.to_string())
             .param("desc", impact_description.unwrap_or("").to_string());
 
-        self.graph.run(q).await?;
+        let mut result = self.graph.execute(q).await?;
+        if result.next().await?.is_none() {
+            anyhow::bail!(
+                "add_decision_affects: no matching {} found for {} (the decision {} or the target entity does not exist in the graph)",
+                label,
+                entity_id,
+                decision_id,
+            );
+        }
         Ok(())
     }
 
     /// Remove an AFFECTS relation from a Decision to an entity.
+    ///
+    /// Symmetric to [`Self::add_decision_affects`]: `entity_type` accepts both
+    /// MCP snake_case and Neo4j PascalCase forms, and the function returns
+    /// `Err` if `entity_type` is unknown or if no matching AFFECTS edge exists
+    /// (so callers can distinguish "nothing to remove" from "successfully
+    /// removed").
     pub async fn remove_decision_affects(
         &self,
         decision_id: Uuid,
         entity_type: &str,
         entity_id: &str,
     ) -> Result<()> {
-        let cypher = if entity_type == "File" && !entity_id.starts_with('/') {
+        let etype = EntityType::from_str(entity_type)
+            .map_err(|e| anyhow::anyhow!("remove_decision_affects: invalid entity_type: {e}"))?;
+        let label = etype.neo4j_label();
+        let match_field = etype.match_property();
+
+        let cypher = if matches!(etype, EntityType::File) && !entity_id.starts_with('/') {
             format!(
                 r#"
-                MATCH (d:Decision {{id: $did}})-[r:AFFECTS]->(e:{}) WHERE e.path ENDS WITH $eid
+                MATCH (d:Decision {{id: $did}})-[r:AFFECTS]->(e:{label}) WHERE e.path ENDS WITH $eid
                 DELETE r
+                RETURN count(r) AS removed
                 "#,
-                entity_type
             )
         } else {
-            let match_field = if entity_type == "File" { "path" } else { "id" };
             format!(
                 r#"
-                MATCH (d:Decision {{id: $did}})-[r:AFFECTS]->(e:{} {{{}: $eid}})
+                MATCH (d:Decision {{id: $did}})-[r:AFFECTS]->(e:{label} {{{match_field}: $eid}})
                 DELETE r
+                RETURN count(r) AS removed
                 "#,
-                entity_type, match_field
             )
         };
 
@@ -567,8 +605,27 @@ impl Neo4jClient {
             .param("did", decision_id.to_string())
             .param("eid", entity_id.to_string());
 
-        self.graph.run(q).await?;
-        Ok(())
+        let mut result = self.graph.execute(q).await?;
+        match result.next().await? {
+            Some(row) => {
+                let removed: i64 = row.get("removed").unwrap_or(0);
+                if removed == 0 {
+                    anyhow::bail!(
+                        "remove_decision_affects: no AFFECTS edge from decision {} to {} {}",
+                        decision_id,
+                        label,
+                        entity_id,
+                    );
+                }
+                Ok(())
+            }
+            None => anyhow::bail!(
+                "remove_decision_affects: query returned no rows (decision {} or {} {} likely missing)",
+                decision_id,
+                label,
+                entity_id,
+            ),
+        }
     }
 
     /// List all entities affected by a Decision.

--- a/src/neo4j/impl_graph_store.rs
+++ b/src/neo4j/impl_graph_store.rs
@@ -440,6 +440,21 @@ impl GraphStore for Neo4jClient {
         self.count_project_files(project_id).await
     }
 
+    async fn count_orphan_files(&self, project_id: Uuid) -> anyhow::Result<i64> {
+        self.count_orphan_files(project_id).await
+    }
+
+    async fn count_co_change_pairs(&self, project_id: Uuid, min_count: i64) -> anyhow::Result<i64> {
+        self.count_co_change_pairs(project_id, min_count).await
+    }
+
+    async fn count_protocol_states_transitions(
+        &self,
+        project_id: Uuid,
+    ) -> anyhow::Result<(i64, i64)> {
+        self.count_protocol_states_transitions(project_id).await
+    }
+
     async fn invalidate_computed_properties(
         &self,
         project_id: Uuid,

--- a/src/neo4j/mock.rs
+++ b/src/neo4j/mock.rs
@@ -1422,6 +1422,18 @@ impl GraphStore for MockGraphStore {
         Ok(pf.get(&project_id).map(|p| p.len() as i64).unwrap_or(0))
     }
 
+    async fn count_orphan_files(&self, _project_id: Uuid) -> Result<i64> {
+        Ok(0)
+    }
+
+    async fn count_co_change_pairs(&self, _project_id: Uuid, _min_count: i64) -> Result<i64> {
+        Ok(0)
+    }
+
+    async fn count_protocol_states_transitions(&self, _project_id: Uuid) -> Result<(i64, i64)> {
+        Ok((0, 0))
+    }
+
     async fn invalidate_computed_properties(
         &self,
         _project_id: Uuid,

--- a/src/neo4j/mock.rs
+++ b/src/neo4j/mock.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use chrono::Utc;
 use std::collections::HashMap;
+use std::str::FromStr;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -4388,8 +4389,17 @@ impl GraphStore for MockGraphStore {
         entity_id: &str,
         impact_description: Option<&str>,
     ) -> Result<()> {
+        // Mirror the real implementation's validation: reject unknown
+        // entity_types up front. The mock has no graph to MATCH against, so it
+        // cannot reproduce the "entity not found" error — but it CAN catch the
+        // case-mismatch / typo class of bug (gotcha e3f9a882), which is the
+        // regression this method previously hid by accepting anything.
+        let etype = crate::notes::models::EntityType::from_str(entity_type)
+            .map_err(|e| anyhow::anyhow!("add_decision_affects: invalid entity_type: {e}"))?;
         let relation = AffectsRelation {
-            entity_type: entity_type.to_string(),
+            // Normalize to the canonical snake_case form so stored relations are
+            // consistent regardless of input casing.
+            entity_type: etype.to_string(),
             entity_id: entity_id.to_string(),
             entity_name: None,
             impact_description: impact_description.map(|s| s.to_string()),
@@ -4406,9 +4416,12 @@ impl GraphStore for MockGraphStore {
     async fn remove_decision_affects(
         &self,
         decision_id: Uuid,
-        _entity_type: &str,
+        entity_type: &str,
         entity_id: &str,
     ) -> Result<()> {
+        // Validate entity_type for symmetry with add_decision_affects.
+        crate::notes::models::EntityType::from_str(entity_type)
+            .map_err(|e| anyhow::anyhow!("remove_decision_affects: invalid entity_type: {e}"))?;
         if let Some(affects) = self.decision_affects.write().await.get_mut(&decision_id) {
             affects.retain(|a| a.entity_id != entity_id);
         }

--- a/src/neo4j/protocol.rs
+++ b/src/neo4j/protocol.rs
@@ -503,6 +503,36 @@ impl Neo4jClient {
         Ok(states)
     }
 
+    /// Count total ProtocolState and ProtocolTransition nodes across all
+    /// protocols of a project, in a single query.
+    ///
+    /// Replaces the previous per-protocol N+1 in the project overview, which
+    /// looped over every protocol and fired two queries each. States and
+    /// transitions are matched by their `protocol_id` property (the same access
+    /// pattern as [`Self::get_protocol_states`]).
+    pub async fn count_protocol_states_transitions(&self, project_id: Uuid) -> Result<(i64, i64)> {
+        let q = query(
+            r#"
+            MATCH (proto:Protocol {project_id: $project_id})
+            WITH collect(proto.id) AS pids
+            OPTIONAL MATCH (s:ProtocolState) WHERE s.protocol_id IN pids
+            WITH pids, count(s) AS states
+            OPTIONAL MATCH (t:ProtocolTransition) WHERE t.protocol_id IN pids
+            RETURN states, count(t) AS transitions
+            "#,
+        )
+        .param("project_id", project_id.to_string());
+
+        let mut result = self.graph.execute(q).await?;
+        if let Some(row) = result.next().await? {
+            let states: i64 = row.get("states").unwrap_or(0);
+            let transitions: i64 = row.get("transitions").unwrap_or(0);
+            Ok((states, transitions))
+        } else {
+            Ok((0, 0))
+        }
+    }
+
     /// Delete a protocol state and its relationships.
     pub async fn delete_protocol_state(&self, state_id: Uuid) -> Result<bool> {
         let check_q = query(

--- a/src/neo4j/traits.rs
+++ b/src/neo4j/traits.rs
@@ -348,6 +348,17 @@ pub trait GraphStore: Send + Sync {
     /// Count files for a project (lightweight, no data transfer)
     async fn count_project_files(&self, project_id: Uuid) -> Result<i64>;
 
+    /// Count orphan files for a project (lightweight — avoids the full health
+    /// report and its distribution fitting). Used by the real-time overview.
+    async fn count_orphan_files(&self, project_id: Uuid) -> Result<i64>;
+
+    /// Count CO_CHANGED pairs for a project (lightweight — no row transfer).
+    async fn count_co_change_pairs(&self, project_id: Uuid, min_count: i64) -> Result<i64>;
+
+    /// Count total protocol states and transitions across a project's protocols
+    /// in a single query (replaces the per-protocol N+1 in the overview).
+    async fn count_protocol_states_transitions(&self, project_id: Uuid) -> Result<(i64, i64)>;
+
     /// Invalidate pre-computed GraIL properties on changed files and their neighbors.
     ///
     /// Sets `*_version = -1` on:

--- a/src/notes/mod.rs
+++ b/src/notes/mod.rs
@@ -10,8 +10,10 @@ pub mod hashing;
 pub mod lifecycle;
 pub mod manager;
 pub mod models;
+pub mod witness;
 
 pub use hashing::*;
 pub use lifecycle::*;
 pub use manager::{BackfillProgress, NoteManager, SynapseBackfillProgress, SynapseConfig};
 pub use models::*;
+pub use witness::{CodeRef, ExternalRef, Witness, WitnessKind, WitnessValidationError};

--- a/src/notes/models.rs
+++ b/src/notes/models.rs
@@ -331,6 +331,62 @@ impl FromStr for EntityType {
     }
 }
 
+impl EntityType {
+    /// Returns the PascalCase label this entity type uses as a node label in
+    /// Neo4j. The MCP and REST surfaces use the snake_case `Display` form
+    /// (`"file"`, `"workspace_milestone"`), while Neo4j labels are PascalCase
+    /// (`:File`, `:WorkspaceMilestone`). Use this method whenever you build a
+    /// Cypher query against an entity whose label was supplied as user input,
+    /// otherwise you build a query against a label that does not exist and the
+    /// MATCH silently produces zero rows.
+    pub fn neo4j_label(&self) -> &'static str {
+        match self {
+            Self::Project => "Project",
+            Self::File => "File",
+            Self::Module => "Module",
+            Self::Function => "Function",
+            Self::Struct => "Struct",
+            Self::Trait => "Trait",
+            Self::Enum => "Enum",
+            Self::Impl => "Impl",
+            Self::Task => "Task",
+            Self::Plan => "Plan",
+            Self::Step => "Step",
+            Self::Commit => "Commit",
+            Self::Decision => "Decision",
+            Self::Constraint => "Constraint",
+            Self::Milestone => "Milestone",
+            Self::Release => "Release",
+            Self::Workspace => "Workspace",
+            Self::WorkspaceMilestone => "WorkspaceMilestone",
+            Self::Resource => "Resource",
+            Self::Component => "Component",
+            Self::FeatureGraph => "FeatureGraph",
+            Self::Protocol => "Protocol",
+            Self::ProtocolState => "ProtocolState",
+            Self::ProtocolRun => "ProtocolRun",
+            Self::PlanRun => "PlanRun",
+            Self::Skill => "Skill",
+            Self::Note => "Note",
+            Self::ChatSession => "ChatSession",
+            Self::Process => "Process",
+        }
+    }
+
+    /// Returns the Cypher property used to look up nodes of this type by their
+    /// external identifier. Most entities are matched by `id` (UUID), but:
+    ///
+    /// - `File` is matched by `path`
+    /// - `Commit` is matched by `hash`
+    pub fn match_property(&self) -> &'static str {
+        match self {
+            Self::File => "path",
+            Self::Commit => "hash",
+            _ => "id",
+        }
+    }
+}
+
 // ============================================================================
 // Scope
 // ============================================================================
@@ -1344,6 +1400,89 @@ mod tests {
             let deserialized: EntityType = serde_json::from_str(&json).unwrap();
             assert_eq!(&deserialized, variant);
         }
+    }
+
+    #[test]
+    fn test_entity_type_neo4j_label_is_pascal_case_for_every_variant() {
+        // The MCP/REST surface speaks lowercase snake_case (Display).
+        // The Neo4j label is the PascalCase variant name. The two MUST agree
+        // across every variant or we silently no-op Cypher queries.
+        let pairs = vec![
+            (EntityType::Project, "Project"),
+            (EntityType::File, "File"),
+            (EntityType::Module, "Module"),
+            (EntityType::Function, "Function"),
+            (EntityType::Struct, "Struct"),
+            (EntityType::Trait, "Trait"),
+            (EntityType::Enum, "Enum"),
+            (EntityType::Impl, "Impl"),
+            (EntityType::Task, "Task"),
+            (EntityType::Plan, "Plan"),
+            (EntityType::Step, "Step"),
+            (EntityType::Commit, "Commit"),
+            (EntityType::Decision, "Decision"),
+            (EntityType::Constraint, "Constraint"),
+            (EntityType::Milestone, "Milestone"),
+            (EntityType::Release, "Release"),
+            (EntityType::Workspace, "Workspace"),
+            (EntityType::WorkspaceMilestone, "WorkspaceMilestone"),
+            (EntityType::Resource, "Resource"),
+            (EntityType::Component, "Component"),
+            (EntityType::FeatureGraph, "FeatureGraph"),
+            (EntityType::Protocol, "Protocol"),
+            (EntityType::ProtocolState, "ProtocolState"),
+            (EntityType::ProtocolRun, "ProtocolRun"),
+            (EntityType::PlanRun, "PlanRun"),
+            (EntityType::Skill, "Skill"),
+            (EntityType::Note, "Note"),
+            (EntityType::ChatSession, "ChatSession"),
+            (EntityType::Process, "Process"),
+        ];
+        for (variant, label) in pairs {
+            assert_eq!(
+                variant.neo4j_label(),
+                label,
+                "variant {variant:?} mapped to the wrong Neo4j label"
+            );
+        }
+    }
+
+    #[test]
+    fn test_entity_type_match_property_specializations() {
+        // File and Commit have non-default match properties; everything else
+        // is keyed by `id`.
+        assert_eq!(EntityType::File.match_property(), "path");
+        assert_eq!(EntityType::Commit.match_property(), "hash");
+        for et in [
+            EntityType::Project,
+            EntityType::Function,
+            EntityType::Task,
+            EntityType::Plan,
+            EntityType::Decision,
+            EntityType::Note,
+            EntityType::ChatSession,
+            EntityType::Process,
+        ] {
+            assert_eq!(et.match_property(), "id", "{et:?} should match by id");
+        }
+    }
+
+    #[test]
+    fn test_entity_type_from_str_accepts_both_cases() {
+        // The MCP layer documents snake_case ("file") but older docs and
+        // human callers may pass PascalCase ("File"). Both must parse — this
+        // is the regression captured by gotcha e3f9a882.
+        assert_eq!(EntityType::from_str("file").unwrap(), EntityType::File);
+        assert_eq!(EntityType::from_str("File").unwrap(), EntityType::File);
+        assert_eq!(
+            EntityType::from_str("workspace_milestone").unwrap(),
+            EntityType::WorkspaceMilestone
+        );
+        assert_eq!(
+            EntityType::from_str("WorkspaceMilestone").unwrap(),
+            EntityType::WorkspaceMilestone
+        );
+        assert!(EntityType::from_str("not_a_real_type").is_err());
     }
 
     #[test]

--- a/src/notes/witness.rs
+++ b/src/notes/witness.rs
@@ -1,0 +1,414 @@
+//! Witness — executable proof anchor for assertive Notes and Decisions.
+//!
+//! Implements the R\* manifesto's "no claim without witness" discipline (Rule 4.3,
+//! RFC `19b89465-6e92-402b-a221-8e9d8e3a3982`). Each assertion in the graph must
+//! either point to:
+//!
+//! - A [`WitnessKind::Proof`] — a formal proof or a piece of source code that
+//!   establishes the claim (e.g. a test that asserts the property, a referenced
+//!   theorem with hash).
+//! - A [`WitnessKind::Certificate`] — an executable witness that can be replayed
+//!   deterministically to verify the cited output (a recorded trajectory or a
+//!   reproducible script).
+//! - [`WitnessKind::Open`] — explicitly marked as unverified hypothesis.
+//!
+//! Validation is enforced at write-time by [`Witness::validate`]. v1 of the RFC
+//! is warn-only at the API boundary; this module returns hard errors so callers
+//! can decide whether to log-and-pass or reject.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use uuid::Uuid;
+
+// ============================================================================
+// Witness kind
+// ============================================================================
+
+/// Epistemic status of an assertion (mapped from the R\* manifesto tags).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum WitnessKind {
+    /// Demonstrated — formal proof or source code that establishes the claim.
+    Proof,
+    /// Certified — executable witness (trajectory or code) replayable on demand.
+    Certificate,
+    /// Open — explicitly unverified hypothesis. Carries no ref.
+    Open,
+}
+
+impl fmt::Display for WitnessKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Proof => write!(f, "proof"),
+            Self::Certificate => write!(f, "certificate"),
+            Self::Open => write!(f, "open"),
+        }
+    }
+}
+
+impl std::str::FromStr for WitnessKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "proof" => Ok(Self::Proof),
+            "certificate" => Ok(Self::Certificate),
+            "open" => Ok(Self::Open),
+            other => Err(format!("Unknown witness kind: {other}")),
+        }
+    }
+}
+
+// ============================================================================
+// Reference types
+// ============================================================================
+
+/// Reference to a specific region of a commit.
+///
+/// Used by [`WitnessKind::Proof`] (e.g. a test that asserts the property) or by
+/// [`WitnessKind::Certificate`] (e.g. a script that produces the cited output).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct CodeRef {
+    /// Full git SHA. We do not accept short SHAs to keep verification
+    /// deterministic across rebases.
+    pub commit_sha: String,
+    /// Path relative to the repository root.
+    pub file_path: String,
+    /// Optional line range `(start, end)` inclusive, 1-indexed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_range: Option<(u32, u32)>,
+}
+
+/// Reference to an external document or page, anchored by content hash so that
+/// drift is detectable.
+///
+/// The `content_hash` is mandatory: an `external_ref` without a hash is
+/// rejected at validation time, regardless of the v1 warn-only API mode.
+/// Rationale: a URL whose content silently changes is the worst possible
+/// witness — its drift cannot be detected by replay.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct ExternalRef {
+    pub url: String,
+    /// SHA-256 hex digest of the canonical fetched content at witness creation.
+    pub content_hash: String,
+}
+
+// ============================================================================
+// Witness
+// ============================================================================
+
+/// An assertion's epistemic anchor.
+///
+/// Invariants enforced by [`Witness::validate`]:
+///
+/// | kind          | code_ref | trajectory_ref | external_ref |
+/// |---------------|----------|----------------|--------------|
+/// | `Proof`       | optional | forbidden      | optional     | (at least one of code/external required)
+/// | `Certificate` | optional | optional       | forbidden    | (at least one of code/trajectory required)
+/// | `Open`        | forbidden| forbidden      | forbidden    |
+///
+/// `Open` is the only kind that carries no ref. It explicitly documents that
+/// the claim is an unverified hypothesis — not a missing witness.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Witness {
+    pub kind: WitnessKind,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_ref: Option<CodeRef>,
+
+    /// UUID of a stored [`Trajectory`](crate::trajectory) that, when replayed,
+    /// produces the cited output. Only valid for [`WitnessKind::Certificate`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trajectory_ref: Option<Uuid>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_ref: Option<ExternalRef>,
+}
+
+/// Validation outcome for a witness.
+#[derive(Debug, thiserror::Error)]
+pub enum WitnessValidationError {
+    #[error("Proof witness must carry at least one of code_ref or external_ref")]
+    ProofMissingRef,
+
+    #[error("Certificate witness must carry at least one of code_ref or trajectory_ref")]
+    CertificateMissingRef,
+
+    #[error("Open witness must not carry any ref (got {0})")]
+    OpenWithRef(&'static str),
+
+    #[error(
+        "Proof witness must not carry trajectory_ref (trajectories are certificates, not proofs)"
+    )]
+    ProofWithTrajectory,
+
+    #[error("Certificate witness must not carry external_ref (external pages are not replayable)")]
+    CertificateWithExternal,
+
+    #[error("external_ref must include a non-empty content_hash (SHA-256 hex) to detect drift")]
+    ExternalRefMissingHash,
+
+    #[error("code_ref.commit_sha must be a full 40-character git SHA (got length {0})")]
+    CodeRefShortSha(usize),
+}
+
+impl Witness {
+    /// Construct an Open witness — the only no-ref variant.
+    pub fn open() -> Self {
+        Self {
+            kind: WitnessKind::Open,
+            code_ref: None,
+            trajectory_ref: None,
+            external_ref: None,
+        }
+    }
+
+    /// Construct a Proof witness backed by a `CodeRef`.
+    pub fn proof_from_code(code_ref: CodeRef) -> Self {
+        Self {
+            kind: WitnessKind::Proof,
+            code_ref: Some(code_ref),
+            trajectory_ref: None,
+            external_ref: None,
+        }
+    }
+
+    /// Construct a Certificate witness backed by a stored trajectory.
+    pub fn certificate_from_trajectory(trajectory_id: Uuid) -> Self {
+        Self {
+            kind: WitnessKind::Certificate,
+            code_ref: None,
+            trajectory_ref: Some(trajectory_id),
+            external_ref: None,
+        }
+    }
+
+    /// Validate the invariants of the (`kind`, refs) tuple.
+    ///
+    /// The content_hash check on `external_ref` is enforced unconditionally
+    /// (see [`WitnessValidationError::ExternalRefMissingHash`]) so that even
+    /// v1 warn-only callers cannot accept a hash-less external reference.
+    pub fn validate(&self) -> Result<(), WitnessValidationError> {
+        // Cross-cutting structural check on the refs themselves, regardless of kind.
+        if let Some(ext) = &self.external_ref {
+            if ext.content_hash.trim().is_empty() {
+                return Err(WitnessValidationError::ExternalRefMissingHash);
+            }
+        }
+        if let Some(code) = &self.code_ref {
+            if code.commit_sha.len() != 40 {
+                return Err(WitnessValidationError::CodeRefShortSha(
+                    code.commit_sha.len(),
+                ));
+            }
+        }
+
+        match self.kind {
+            WitnessKind::Proof => {
+                if self.trajectory_ref.is_some() {
+                    return Err(WitnessValidationError::ProofWithTrajectory);
+                }
+                if self.code_ref.is_none() && self.external_ref.is_none() {
+                    return Err(WitnessValidationError::ProofMissingRef);
+                }
+                Ok(())
+            }
+            WitnessKind::Certificate => {
+                if self.external_ref.is_some() {
+                    return Err(WitnessValidationError::CertificateWithExternal);
+                }
+                if self.code_ref.is_none() && self.trajectory_ref.is_none() {
+                    return Err(WitnessValidationError::CertificateMissingRef);
+                }
+                Ok(())
+            }
+            WitnessKind::Open => {
+                if self.code_ref.is_some() {
+                    return Err(WitnessValidationError::OpenWithRef("code_ref"));
+                }
+                if self.trajectory_ref.is_some() {
+                    return Err(WitnessValidationError::OpenWithRef("trajectory_ref"));
+                }
+                if self.external_ref.is_some() {
+                    return Err(WitnessValidationError::OpenWithRef("external_ref"));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Whether this witness can in principle be re-executed to produce its
+    /// cited output (i.e. replayable [C] in manifesto terms).
+    pub fn is_replayable(&self) -> bool {
+        matches!(self.kind, WitnessKind::Certificate)
+            && (self.code_ref.is_some() || self.trajectory_ref.is_some())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_code_ref() -> CodeRef {
+        CodeRef {
+            commit_sha: "a".repeat(40),
+            file_path: "src/example.rs".to_string(),
+            line_range: Some((10, 42)),
+        }
+    }
+
+    fn dummy_external_ref() -> ExternalRef {
+        ExternalRef {
+            url: "https://example.org/spec".to_string(),
+            content_hash: "deadbeef".repeat(8), // 64 hex chars, plausible SHA-256
+        }
+    }
+
+    #[test]
+    fn proof_with_code_ref_ok() {
+        let w = Witness::proof_from_code(dummy_code_ref());
+        assert!(w.validate().is_ok());
+        assert!(
+            !w.is_replayable(),
+            "Proof is not replayable as a Certificate is"
+        );
+    }
+
+    #[test]
+    fn proof_with_external_ref_ok() {
+        let w = Witness {
+            kind: WitnessKind::Proof,
+            code_ref: None,
+            trajectory_ref: None,
+            external_ref: Some(dummy_external_ref()),
+        };
+        assert!(w.validate().is_ok());
+    }
+
+    #[test]
+    fn proof_without_any_ref_fails() {
+        let w = Witness {
+            kind: WitnessKind::Proof,
+            code_ref: None,
+            trajectory_ref: None,
+            external_ref: None,
+        };
+        assert!(matches!(
+            w.validate(),
+            Err(WitnessValidationError::ProofMissingRef)
+        ));
+    }
+
+    #[test]
+    fn certificate_with_trajectory_ok_and_replayable() {
+        let w = Witness::certificate_from_trajectory(Uuid::new_v4());
+        assert!(w.validate().is_ok());
+        assert!(w.is_replayable());
+    }
+
+    #[test]
+    fn open_with_ref_fails() {
+        let w = Witness {
+            kind: WitnessKind::Open,
+            code_ref: Some(dummy_code_ref()),
+            trajectory_ref: None,
+            external_ref: None,
+        };
+        assert!(matches!(
+            w.validate(),
+            Err(WitnessValidationError::OpenWithRef("code_ref"))
+        ));
+    }
+
+    #[test]
+    fn external_ref_without_hash_fails_even_when_kind_would_accept() {
+        // Even though Proof accepts external_ref, the structural check on
+        // content_hash fires unconditionally (security constraint of the RFC).
+        let w = Witness {
+            kind: WitnessKind::Proof,
+            code_ref: None,
+            trajectory_ref: None,
+            external_ref: Some(ExternalRef {
+                url: "https://example.org/spec".to_string(),
+                content_hash: "   ".to_string(),
+            }),
+        };
+        assert!(matches!(
+            w.validate(),
+            Err(WitnessValidationError::ExternalRefMissingHash)
+        ));
+    }
+
+    #[test]
+    fn proof_with_trajectory_fails() {
+        let w = Witness {
+            kind: WitnessKind::Proof,
+            code_ref: Some(dummy_code_ref()),
+            trajectory_ref: Some(Uuid::new_v4()),
+            external_ref: None,
+        };
+        assert!(matches!(
+            w.validate(),
+            Err(WitnessValidationError::ProofWithTrajectory)
+        ));
+    }
+
+    #[test]
+    fn certificate_with_external_fails() {
+        let w = Witness {
+            kind: WitnessKind::Certificate,
+            code_ref: None,
+            trajectory_ref: Some(Uuid::new_v4()),
+            external_ref: Some(dummy_external_ref()),
+        };
+        assert!(matches!(
+            w.validate(),
+            Err(WitnessValidationError::CertificateWithExternal)
+        ));
+    }
+
+    #[test]
+    fn code_ref_short_sha_fails() {
+        let w = Witness {
+            kind: WitnessKind::Proof,
+            code_ref: Some(CodeRef {
+                commit_sha: "abc1234".to_string(),
+                file_path: "src/example.rs".to_string(),
+                line_range: None,
+            }),
+            trajectory_ref: None,
+            external_ref: None,
+        };
+        assert!(matches!(
+            w.validate(),
+            Err(WitnessValidationError::CodeRefShortSha(7))
+        ));
+    }
+
+    #[test]
+    fn witness_kind_serde_snake_case() {
+        let w = Witness::open();
+        let json = serde_json::to_string(&w).unwrap();
+        assert!(json.contains("\"kind\":\"open\""));
+
+        let back: Witness = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, w);
+    }
+
+    #[test]
+    fn witness_kind_from_str_roundtrip() {
+        for kind in [
+            WitnessKind::Proof,
+            WitnessKind::Certificate,
+            WitnessKind::Open,
+        ] {
+            let parsed: WitnessKind = kind.to_string().parse().unwrap();
+            assert_eq!(parsed, kind);
+        }
+        assert!("bogus".parse::<WitnessKind>().is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Single testable branch. Two themes: the R\* epistemic-discipline foundation, and a cluster of performance fixes surfaced while working in the codebase. **Five commits:**

1. `feat(notes)` `495ba89` — Witness schema (R\* / RFC 19b89465)
2. `fix(decision)` `72bc0fb` — decision.add_affects silent no-op (**verified live** post-redeploy)
3. `perf(chat)` `06d58f1` — index ChatSession.updated_at → faster **conversation list**
4. `perf(chat)` `4bebe6f` — composite (session_id, seq) index + property-match → faster **message loading on conversation open**
5. `perf(overview)` `1f27e5d` — kill over-fetch + N+1 in build_intelligence_summary → faster **project overview** (stays real-time, no cache)

---

### 1. Witness schema (R\*)
`WitnessKind` = Proof / Certificate / Open with strict (kind × ref) validation. 11 unit tests. Schema only; API wiring later. Pins rust-toolchain.toml to 1.95.0.

### 2. decision.add_affects fix — VERIFIED LIVE
Was injecting the raw entity_type as the Neo4j label (`"file"` → nonexistent `:file`), and a no-RETURN `run()` hid the empty MATCH → silent `{status:ok}`, edge never created. Fixed with EntityType::neo4j_label()/match_property(), RETURN + execute() + bail! on zero rows. **Confirmed on the redeployed server**: missing node → HTTP 500 (was silent ok); existing node → edge created; list_affects returns it (was always []).

### 3. Conversation list
`ORDER BY s.updated_at DESC SKIP/LIMIT` with no index on updated_at → full scan + sort of every session per list load. Added range indexes (updated_at, (project_slug, updated_at), conversation_id).

### 4. Message loading on open
count_chat_events + get_chat_events_paginated drove off `(s)-[:HAS_EVENT]->(e)` then sorted by seq in memory. Added composite index chat_event_session_seq (session_id, seq) and rewrote both to MATCH (e:ChatEvent {session_id}) → index-backed ORDER BY + LIMIT. Equivalent (every event carries session_id).

### 5. Project overview (real-time, no cache)
build_intelligence_summary fired 13 parallel queries but three over-worked:
- get_code_health_report (PageRank/risk distribution fitting, 10 laws) used only for orphan_files.len()
- get_co_change_graph(…, 100_000) pulled up to 100k pairs for .len()
- per-protocol N+1 (states + transitions per protocol)
Replaced with count_orphan_files / count_co_change_pairs / count_protocol_states_transitions (new GraphStore methods), all fired in the same join. Live counts preserved — the fix is to stop over-computing, not to cache. Note: orphan count was previously capped at 20; now returns the true total.

---

## Validation (whole branch)
- [x] cargo test notes:: → 100 passed
- [x] cargo check / clippy -D warnings / rustfmt --check — clean
- [x] cargo build --release — green
- [x] Pre-push hook green on every push
- [x] decision.add_affects verified end-to-end on the live server

## Deploy
Rebuild + restart the orchestrator on :8080. **Confirm `lsof -iTCP:8080 -sTCP:LISTEN` shows the NEW pid** — a restart that doesn't kill the old process leaves 8080 held by the old binary (learned the hard way this session). Chat indexes are created at startup; the overview/add_affects fixes take effect immediately.

## Linked PO graph
RFC 19b89465 · Plan 5af0d16a · gotchas e3f9a882 (add_affects, closed [C]), 70ce7859 (conv-list), a822a378 (overview). Supersedes #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)