### PR TITLE
fix(decision): add/remove_decision_affects fail loudly instead of silent no-op

### DIFF
--- a/src/neo4j/decision.rs
+++ b/src/neo4j/decision.rs
@@ -2,8 +2,10 @@
 
 use super::client::Neo4jClient;
 use super::models::*;
+use crate::notes::models::EntityType;
 use anyhow::Result;
 use neo4rs::query;
+use std::str::FromStr;
 use uuid::Uuid;
 
 impl Neo4jClient {
@@ -493,8 +495,22 @@ impl Neo4jClient {
 
     /// Create an AFFECTS relation from a Decision to any entity in the graph.
     ///
-    /// The entity is matched by a generic `{id: $entity_id}` or `{path: $entity_id}`
-    /// (for File nodes). The `impact_description` is optional free-text.
+    /// `entity_type` is parsed via [`EntityType::from_str`] so callers may pass
+    /// the snake_case MCP convention (`"file"`, `"workspace_milestone"`) or the
+    /// PascalCase Neo4j label form (`"File"`, `"WorkspaceMilestone"`) —
+    /// internally we always use the canonical [`EntityType::neo4j_label`] to
+    /// build the Cypher.
+    ///
+    /// The entity is matched by [`EntityType::match_property`] (`path` for
+    /// `File`, `hash` for `Commit`, `id` for everything else). For `File`
+    /// targets, a relative `entity_id` (not starting with `/`) is matched via
+    /// `ENDS WITH` against the stored absolute path, preserving the previous
+    /// behaviour for convenience.
+    ///
+    /// Returns `Err` if `entity_type` is not a recognized variant, or if the
+    /// Decision and entity could not both be matched in the graph (previously
+    /// this case was a silent no-op which made the AFFECTS edge an
+    /// unverifiable claim — see the R\* RFC `19b89465`).
     pub async fn add_decision_affects(
         &self,
         decision_id: Uuid,
@@ -502,29 +518,33 @@ impl Neo4jClient {
         entity_id: &str,
         impact_description: Option<&str>,
     ) -> Result<()> {
-        let cypher = if entity_type == "File" && !entity_id.starts_with('/') {
-            // Relative path: use ENDS WITH to match against full absolute paths
+        let etype = EntityType::from_str(entity_type)
+            .map_err(|e| anyhow::anyhow!("add_decision_affects: invalid entity_type: {e}"))?;
+        let label = etype.neo4j_label();
+        let match_field = etype.match_property();
+
+        let cypher = if matches!(etype, EntityType::File) && !entity_id.starts_with('/') {
+            // Relative path: match against full absolute paths via ENDS WITH.
             format!(
                 r#"
                 MATCH (d:Decision {{id: $did}})
-                MATCH (e:{} ) WHERE e.path ENDS WITH $eid
+                MATCH (e:{label}) WHERE e.path ENDS WITH $eid
                 MERGE (d)-[r:AFFECTS]->(e)
                 SET r.impact_description = $desc,
                     r.created_at = datetime()
+                RETURN d.id AS did, e.path AS matched
                 "#,
-                entity_type
             )
         } else {
-            let match_field = if entity_type == "File" { "path" } else { "id" };
             format!(
                 r#"
                 MATCH (d:Decision {{id: $did}})
-                MATCH (e:{} {{{}: $eid}})
+                MATCH (e:{label} {{{match_field}: $eid}})
                 MERGE (d)-[r:AFFECTS]->(e)
                 SET r.impact_description = $desc,
                     r.created_at = datetime()
+                RETURN d.id AS did, e.{match_field} AS matched
                 "#,
-                entity_type, match_field
             )
         };
 
@@ -533,33 +553,51 @@ impl Neo4jClient {
             .param("eid", entity_id.to_string())
             .param("desc", impact_description.unwrap_or("").to_string());
 
-        self.graph.run(q).await?;
+        let mut result = self.graph.execute(q).await?;
+        if result.next().await?.is_none() {
+            anyhow::bail!(
+                "add_decision_affects: no matching {} found for {} (the decision {} or the target entity does not exist in the graph)",
+                label,
+                entity_id,
+                decision_id,
+            );
+        }
         Ok(())
     }
 
     /// Remove an AFFECTS relation from a Decision to an entity.
+    ///
+    /// Symmetric to [`Self::add_decision_affects`]: `entity_type` accepts both
+    /// MCP snake_case and Neo4j PascalCase forms, and the function returns
+    /// `Err` if `entity_type` is unknown or if no matching AFFECTS edge exists
+    /// (so callers can distinguish "nothing to remove" from "successfully
+    /// removed").
     pub async fn remove_decision_affects(
         &self,
         decision_id: Uuid,
         entity_type: &str,
         entity_id: &str,
     ) -> Result<()> {
-        let cypher = if entity_type == "File" && !entity_id.starts_with('/') {
+        let etype = EntityType::from_str(entity_type)
+            .map_err(|e| anyhow::anyhow!("remove_decision_affects: invalid entity_type: {e}"))?;
+        let label = etype.neo4j_label();
+        let match_field = etype.match_property();
+
+        let cypher = if matches!(etype, EntityType::File) && !entity_id.starts_with('/') {
             format!(
                 r#"
-                MATCH (d:Decision {{id: $did}})-[r:AFFECTS]->(e:{}) WHERE e.path ENDS WITH $eid
+                MATCH (d:Decision {{id: $did}})-[r:AFFECTS]->(e:{label}) WHERE e.path ENDS WITH $eid
                 DELETE r
+                RETURN count(r) AS removed
                 "#,
-                entity_type
             )
         } else {
-            let match_field = if entity_type == "File" { "path" } else { "id" };
             format!(
                 r#"
-                MATCH (d:Decision {{id: $did}})-[r:AFFECTS]->(e:{} {{{}: $eid}})
+                MATCH (d:Decision {{id: $did}})-[r:AFFECTS]->(e:{label} {{{match_field}: $eid}})
                 DELETE r
+                RETURN count(r) AS removed
                 "#,
-                entity_type, match_field
             )
         };
 
@@ -567,8 +605,27 @@ impl Neo4jClient {
             .param("did", decision_id.to_string())
             .param("eid", entity_id.to_string());
 
-        self.graph.run(q).await?;
-        Ok(())
+        let mut result = self.graph.execute(q).await?;
+        match result.next().await? {
+            Some(row) => {
+                let removed: i64 = row.get("removed").unwrap_or(0);
+                if removed == 0 {
+                    anyhow::bail!(
+                        "remove_decision_affects: no AFFECTS edge from decision {} to {} {}",
+                        decision_id,
+                        label,
+                        entity_id,
+                    );
+                }
+                Ok(())
+            }
+            None => anyhow::bail!(
+                "remove_decision_affects: query returned no rows (decision {} or {} {} likely missing)",
+                decision_id,
+                label,
+                entity_id,
+            ),
+        }
     }
 
     /// List all entities affected by a Decision.

--- a/src/neo4j/mock.rs
+++ b/src/neo4j/mock.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use chrono::Utc;
 use std::collections::HashMap;
+use std::str::FromStr;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -4388,8 +4389,17 @@ impl GraphStore for MockGraphStore {
         entity_id: &str,
         impact_description: Option<&str>,
     ) -> Result<()> {
+        // Mirror the real implementation's validation: reject unknown
+        // entity_types up front. The mock has no graph to MATCH against, so it
+        // cannot reproduce the "entity not found" error — but it CAN catch the
+        // case-mismatch / typo class of bug (gotcha e3f9a882), which is the
+        // regression this method previously hid by accepting anything.
+        let etype = crate::notes::models::EntityType::from_str(entity_type)
+            .map_err(|e| anyhow::anyhow!("add_decision_affects: invalid entity_type: {e}"))?;
         let relation = AffectsRelation {
-            entity_type: entity_type.to_string(),
+            // Normalize to the canonical snake_case form so stored relations are
+            // consistent regardless of input casing.
+            entity_type: etype.to_string(),
             entity_id: entity_id.to_string(),
             entity_name: None,
             impact_description: impact_description.map(|s| s.to_string()),
@@ -4406,9 +4416,12 @@ impl GraphStore for MockGraphStore {
     async fn remove_decision_affects(
         &self,
         decision_id: Uuid,
-        _entity_type: &str,
+        entity_type: &str,
         entity_id: &str,
     ) -> Result<()> {
+        // Validate entity_type for symmetry with add_decision_affects.
+        crate::notes::models::EntityType::from_str(entity_type)
+            .map_err(|e| anyhow::anyhow!("remove_decision_affects: invalid entity_type: {e}"))?;
         if let Some(affects) = self.decision_affects.write().await.get_mut(&decision_id) {
             affects.retain(|a| a.entity_id != entity_id);
         }

--- a/src/notes/models.rs
+++ b/src/notes/models.rs
@@ -331,6 +331,62 @@ impl FromStr for EntityType {
     }
 }
 
+impl EntityType {
+    /// Returns the PascalCase label this entity type uses as a node label in
+    /// Neo4j. The MCP and REST surfaces use the snake_case `Display` form
+    /// (`"file"`, `"workspace_milestone"`), while Neo4j labels are PascalCase
+    /// (`:File`, `:WorkspaceMilestone`). Use this method whenever you build a
+    /// Cypher query against an entity whose label was supplied as user input,
+    /// otherwise you build a query against a label that does not exist and the
+    /// MATCH silently produces zero rows.
+    pub fn neo4j_label(&self) -> &'static str {
+        match self {
+            Self::Project => "Project",
+            Self::File => "File",
+            Self::Module => "Module",
+            Self::Function => "Function",
+            Self::Struct => "Struct",
+            Self::Trait => "Trait",
+            Self::Enum => "Enum",
+            Self::Impl => "Impl",
+            Self::Task => "Task",
+            Self::Plan => "Plan",
+            Self::Step => "Step",
+            Self::Commit => "Commit",
+            Self::Decision => "Decision",
+            Self::Constraint => "Constraint",
+            Self::Milestone => "Milestone",
+            Self::Release => "Release",
+            Self::Workspace => "Workspace",
+            Self::WorkspaceMilestone => "WorkspaceMilestone",
+            Self::Resource => "Resource",
+            Self::Component => "Component",
+            Self::FeatureGraph => "FeatureGraph",
+            Self::Protocol => "Protocol",
+            Self::ProtocolState => "ProtocolState",
+            Self::ProtocolRun => "ProtocolRun",
+            Self::PlanRun => "PlanRun",
+            Self::Skill => "Skill",
+            Self::Note => "Note",
+            Self::ChatSession => "ChatSession",
+            Self::Process => "Process",
+        }
+    }
+
+    /// Returns the Cypher property used to look up nodes of this type by their
+    /// external identifier. Most entities are matched by `id` (UUID), but:
+    ///
+    /// - `File` is matched by `path`
+    /// - `Commit` is matched by `hash`
+    pub fn match_property(&self) -> &'static str {
+        match self {
+            Self::File => "path",
+            Self::Commit => "hash",
+            _ => "id",
+        }
+    }
+}
+
 // ============================================================================
 // Scope
 // ============================================================================
@@ -1344,6 +1400,89 @@ mod tests {
             let deserialized: EntityType = serde_json::from_str(&json).unwrap();
             assert_eq!(&deserialized, variant);
         }
+    }
+
+    #[test]
+    fn test_entity_type_neo4j_label_is_pascal_case_for_every_variant() {
+        // The MCP/REST surface speaks lowercase snake_case (Display).
+        // The Neo4j label is the PascalCase variant name. The two MUST agree
+        // across every variant or we silently no-op Cypher queries.
+        let pairs = vec![
+            (EntityType::Project, "Project"),
+            (EntityType::File, "File"),
+            (EntityType::Module, "Module"),
+            (EntityType::Function, "Function"),
+            (EntityType::Struct, "Struct"),
+            (EntityType::Trait, "Trait"),
+            (EntityType::Enum, "Enum"),
+            (EntityType::Impl, "Impl"),
+            (EntityType::Task, "Task"),
+            (EntityType::Plan, "Plan"),
+            (EntityType::Step, "Step"),
+            (EntityType::Commit, "Commit"),
+            (EntityType::Decision, "Decision"),
+            (EntityType::Constraint, "Constraint"),
+            (EntityType::Milestone, "Milestone"),
+            (EntityType::Release, "Release"),
+            (EntityType::Workspace, "Workspace"),
+            (EntityType::WorkspaceMilestone, "WorkspaceMilestone"),
+            (EntityType::Resource, "Resource"),
+            (EntityType::Component, "Component"),
+            (EntityType::FeatureGraph, "FeatureGraph"),
+            (EntityType::Protocol, "Protocol"),
+            (EntityType::ProtocolState, "ProtocolState"),
+            (EntityType::ProtocolRun, "ProtocolRun"),
+            (EntityType::PlanRun, "PlanRun"),
+            (EntityType::Skill, "Skill"),
+            (EntityType::Note, "Note"),
+            (EntityType::ChatSession, "ChatSession"),
+            (EntityType::Process, "Process"),
+        ];
+        for (variant, label) in pairs {
+            assert_eq!(
+                variant.neo4j_label(),
+                label,
+                "variant {variant:?} mapped to the wrong Neo4j label"
+            );
+        }
+    }
+
+    #[test]
+    fn test_entity_type_match_property_specializations() {
+        // File and Commit have non-default match properties; everything else
+        // is keyed by `id`.
+        assert_eq!(EntityType::File.match_property(), "path");
+        assert_eq!(EntityType::Commit.match_property(), "hash");
+        for et in [
+            EntityType::Project,
+            EntityType::Function,
+            EntityType::Task,
+            EntityType::Plan,
+            EntityType::Decision,
+            EntityType::Note,
+            EntityType::ChatSession,
+            EntityType::Process,
+        ] {
+            assert_eq!(et.match_property(), "id", "{et:?} should match by id");
+        }
+    }
+
+    #[test]
+    fn test_entity_type_from_str_accepts_both_cases() {
+        // The MCP layer documents snake_case ("file") but older docs and
+        // human callers may pass PascalCase ("File"). Both must parse — this
+        // is the regression captured by gotcha e3f9a882.
+        assert_eq!(EntityType::from_str("file").unwrap(), EntityType::File);
+        assert_eq!(EntityType::from_str("File").unwrap(), EntityType::File);
+        assert_eq!(
+            EntityType::from_str("workspace_milestone").unwrap(),
+            EntityType::WorkspaceMilestone
+        );
+        assert_eq!(
+            EntityType::from_str("WorkspaceMilestone").unwrap(),
+            EntityType::WorkspaceMilestone
+        );
+        assert!(EntityType::from_str("not_a_real_type").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`decision.add_affects` returned `Ok` (the MCP layer surfaced `{status: ok}`) **without ever creating the AFFECTS edge** whenever `entity_type` was not the exact literal `"File"`. This silently corrupted the `Decision → AFFECTS → entity` axis of the knowledge graph.

## Root cause

Two compounding bugs in `src/neo4j/decision.rs`:

1. **Raw string as Neo4j label.** The handler injected the `entity_type` string directly as the node label in the Cypher MATCH. The MCP spec and `note.link_to_entity` use lowercase `"file"`, which produced the label `:file` — nonexistent, because Neo4j labels are case-sensitive PascalCase (`:File`). The MATCH bound zero nodes.
2. **Silent success on empty MATCH.** The Cypher had no `RETURN` and used `graph.run()`, which does not surface a zero-row MATCH. A `MERGE` after an empty MATCH is a no-op, so a non-match was indistinguishable from a real write.

Net effect: every `entity_type` except exactly `"File"` silently did nothing; even `"File"` did nothing on an unresolved path — with no error returned.

## Fix

- Add `EntityType::neo4j_label()` (canonical PascalCase label) and `EntityType::match_property()` (`path` for File, `hash` for Commit, `id` otherwise) on the existing `EntityType` enum.
- Rewrite `add_decision_affects` / `remove_decision_affects` to: parse `entity_type` via `EntityType::from_str` (accepts **both** `"file"` and `"File"`), use the canonical label, add a `RETURN` clause, switch to `graph.execute()`, and `bail!` with a descriptive error when zero rows match.
- Mirror the `entity_type` validation in the mock so unit tests catch the casing/typo class of bug.

## Tests

- [x] `cargo test notes::` → **100 passed, 0 failed**
- [x] New regression tests: `neo4j_label` coverage for all 29 variants, `match_property` specializations, `from_str` case-insensitivity
- [x] `rustfmt --check` clean
- [x] `cargo clippy --lib -- -D warnings` clean
- [x] `cargo build --release` green (17m)
- [x] Pre-push hook (`cargo check --all-targets --all-features`) green (12m)

## Deployment note

This is a code + unit-test fix. The **running PO MCP server still carries the old binary**, so a live `decision.add_affects` call will keep exhibiting the bug until this merges and the server is rebuilt + restarted. End-to-end verification against the live graph is a post-merge step.

## Context

Discovered organically while applying the **R\* witness discipline** (RFC `19b89465`): the act of linking a Decision to its affected files surfaced this latent silent failure. A `Decision` whose `AFFECTS` edge never persists is, in R\* terms, an unverifiable claim — which is exactly what the discipline is meant to eliminate.

Linked PO graph entities:
- Gotcha: \`e3f9a882-d715-4ec0-9a5e-a9fa0b481fd1\` (full root-cause analysis)
- Task: \`bfd0c116-36e8-4340-ac99-7d9d39034b74\` (T4)
- Plan: \`5af0d16a-d9c5-4ba2-9218-b14c990d0e08\` (R\* Wave 1)
- Related PR: #354 (Witness schema — the discipline that surfaced this bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)