### PR TITLE
ci: lint & test the whole workspace (close the member-crate blind spot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,13 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        # --workspace so EVERY member crate is linted (neural-routing-*,
+        # tree-sitter-*), not just the root package. Without it, member crates
+        # only compile as path-dependencies and their own targets/tests are
+        # never linted. project-orchestrator-desktop is excluded until its
+        # bollard 0.21 migration lands (tracked) — it doesn't compile on main
+        # and needs Tauri system deps + the frontend dist to build on CI.
+        run: cargo clippy --workspace --exclude project-orchestrator-desktop --all-targets --all-features -- -D warnings
 
   # ==========================================================================
   # Unit Tests - Library and parser tests without external services
@@ -134,7 +140,11 @@ jobs:
           save-if: false
 
       - name: Run unit tests (lib)
-        run: cargo test --lib
+        # --workspace so member crates' unit tests actually run in CI (the
+        # neural-routing-* crates carry their own #[cfg(test)] suites that the
+        # root-only `cargo test --lib` never executed). Desktop excluded — see
+        # the clippy step.
+        run: cargo test --workspace --exclude project-orchestrator-desktop --lib
 
       - name: Run parser tests
         run: cargo test --test parser_tests

--- a/crates/neural-routing-gnn/src/benchmark/mod.rs
+++ b/crates/neural-routing-gnn/src/benchmark/mod.rs
@@ -1124,8 +1124,8 @@ mod tests {
         // Both should produce valid AUC-ROC
         let gnn_auc = gnn_metrics.auc_roc.unwrap();
         let voyage_auc = voyage_metrics.auc_roc.unwrap();
-        assert!(gnn_auc >= 0.0 && gnn_auc <= 1.0);
-        assert!(voyage_auc >= 0.0 && voyage_auc <= 1.0);
+        assert!((0.0..=1.0).contains(&gnn_auc));
+        assert!((0.0..=1.0).contains(&voyage_auc));
 
         info!(
             "Co-change AUC: GNN={:.3}, Voyage={:.3}",

--- a/crates/neural-routing-gnn/src/training.rs
+++ b/crates/neural-routing-gnn/src/training.rs
@@ -1305,7 +1305,7 @@ mod tests {
         // Zero: log(1+exp(0)) = log(2) ≈ 0.693
         let zero = Tensor::new(&[0.0f32], &device)?;
         let result = log1p_exp(&zero)?.to_vec1::<f32>()?;
-        assert!((result[0] - 0.6931).abs() < 0.01);
+        assert!((result[0] - std::f32::consts::LN_2).abs() < 0.01);
 
         Ok(())
     }

--- a/crates/neural-routing-policy/src/ewc.rs
+++ b/crates/neural-routing-policy/src/ewc.rs
@@ -261,7 +261,7 @@ mod tests {
 
         // Fisher = all ones
         let grad = Tensor::ones((4,), DType::F32, &device).unwrap();
-        ewc.snapshot_from_gradients(&varmap, &vec![("param".to_string(), vec![grad])])
+        ewc.snapshot_from_gradients(&varmap, &[("param".to_string(), vec![grad])])
             .unwrap();
 
         // Now mutate the parameter via the Var stored in VarMap

--- a/crates/neural-routing-runtime/src/collector.rs
+++ b/crates/neural-routing-runtime/src/collector.rs
@@ -1731,7 +1731,7 @@ mod tests {
         };
 
         // The extraction logic: buffer.decisions.iter().find_map(|d| d.protocol_run_id)
-        let decisions = vec![d1, d2];
+        let decisions = [d1, d2];
         let extracted = decisions.iter().find_map(|d| d.protocol_run_id);
         assert_eq!(extracted, Some(run_id));
     }
@@ -1754,7 +1754,7 @@ mod tests {
             protocol_run_id: None,
             protocol_state: None,
         };
-        let decisions = vec![d1];
+        let decisions = [d1];
         let extracted: Option<uuid::Uuid> = decisions.iter().find_map(|d| d.protocol_run_id);
         assert_eq!(extracted, None);
     }

--- a/crates/neural-routing-runtime/src/exploration.rs
+++ b/crates/neural-routing-runtime/src/exploration.rs
@@ -528,7 +528,11 @@ mod tests {
     fn test_splitmix_uniform_range() {
         for seed in 0..1000u64 {
             let u = splitmix_uniform(seed);
-            assert!(u >= 0.0 && u < 1.0, "Uniform sample out of range: {}", u);
+            assert!(
+                (0.0..1.0).contains(&u),
+                "Uniform sample out of range: {}",
+                u
+            );
         }
     }
 
@@ -617,7 +621,7 @@ mod tests {
     fn test_sort_by_total_cmp_handles_nan() {
         // Regression: sort_by(partial_cmp().unwrap()) panics on NaN.
         // total_cmp handles NaN deterministically (NaN sorts after all values).
-        let mut values = vec![0.5, f64::NAN, 0.3, 0.7, f64::NAN, 0.1];
+        let mut values = [0.5, f64::NAN, 0.3, 0.7, f64::NAN, 0.1];
         values.sort_by(|a, b| a.total_cmp(b));
         // Should not panic; NaN sorts to the end
         assert_eq!(values[0], 0.1);


### PR DESCRIPTION
## Summary

First brick of the **"last 30%" — immune system** workstream. Makes CI actually check the whole workspace, and fixes the latent debt that surfaced the moment it did.

## Root cause

The root `Cargo.toml` is both `[workspace]` **and** `[package]` (no `default-members`). So `cargo clippy`/`test`/`build` at the root operate on the **root package only** — never the members. Result:

- `crates/*` (neural-routing-{core,gnn,nn,policy,runtime}, tree-sitter-{dart,hcl}) compiled only as path-deps; their own targets and `#[cfg(test)]` suites were never linted or run.
- `desktop/src-tauri` was **never compiled at all** — which is how it rotted against bollard 0.21 since #340 without CI noticing.

Both `ci.yml` and the local pre-push hook used `cargo clippy --all-targets --all-features` **without `--workspace`**.

## Changes

- `ci.yml`: clippy + unit-tests now run `--workspace --exclude project-orchestrator-desktop`.
- Local pre-push hook aligned (not versioned, but updated for consistency).
- **8 latent clippy findings** in member crates, surfaced the instant `--workspace` ran, all fixed (test code, no behavior change):
  - `useless_vec` ×4, `manual_range_contains` ×3, `approx_constant` ×1 (hardcoded `0.6931` → `std::f32::consts::LN_2`).

`desktop` stays excluded until its bollard 0.21 migration lands (it needs Tauri system deps + the frontend `dist/` to build on CI). Tracked as a follow-up.

## Validation

- [x] `cargo check --workspace --exclude project-orchestrator-desktop` — green
- [x] `cargo clippy --workspace --exclude project-orchestrator-desktop --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Pre-push hook (now running the `--workspace` clippy) — green

## Important follow-ups (tracked)

1. **Make CI checks REQUIRED in branch protection** — they exist but aren't required, so PRs merge even when CI is red (#356 merged in `UNSTABLE`). This is the piece that actually gates merges. Repo setting, not code.
2. **Migrate `docker.rs` to bollard 0.21**, then add a `desktop` CI job and drop the `--exclude`.

PO graph: plan `29dfc3d1` (Last 30% — Wave 1: Immune system), gotcha `99b008d0` (root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)