### PR TITLE
fix(knowledge-fabric): enforce anchoring + improve agent context injection

### DIFF
--- a/src/chat/skill_hook.rs
+++ b/src/chat/skill_hook.rs
@@ -262,7 +262,11 @@ impl SkillActivationHook {
         let id = Uuid::parse_str(entity_id).ok()?;
         let note = self.graph_store.get_note(id).await.ok().flatten()?;
         // Collapse whitespace/newlines into a single line.
-        let mut text: String = note.content.split_whitespace().collect::<Vec<_>>().join(" ");
+        let mut text: String = note
+            .content
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
         if text.chars().count() > MAX_CHARS {
             text = text.chars().take(MAX_CHARS).collect::<String>();
             text.push('…');
@@ -352,8 +356,9 @@ impl SkillActivationHook {
                         self.graph_store.get_persona_subgraph(*linked_id).await
                     {
                         for note_rel in linked_subgraph.notes.iter().take(3) {
-                            if let Some(line) =
-                                self.note_snippet(&note_rel.entity_id, note_rel.weight).await
+                            if let Some(line) = self
+                                .note_snippet(&note_rel.entity_id, note_rel.weight)
+                                .await
                             {
                                 ctx.push_str("  ");
                                 ctx.push_str(&line);

--- a/src/chat/skill_hook.rs
+++ b/src/chat/skill_hook.rs
@@ -251,6 +251,25 @@ impl SkillActivationHook {
         dir_index
     }
 
+    /// Fetch a note by its UUID string and render a one-line, weight-prefixed
+    /// content snippet. Returns None if the id is invalid or the note is missing.
+    ///
+    /// This is what makes the injected context *usable*: the agent receives the
+    /// actual knowledge ("Always validate the workspace before...") instead of a
+    /// bare `[note:uuid]` it would have to resolve with another tool call.
+    async fn note_snippet(&self, entity_id: &str, weight: f64) -> Option<String> {
+        const MAX_CHARS: usize = 160;
+        let id = Uuid::parse_str(entity_id).ok()?;
+        let note = self.graph_store.get_note(id).await.ok().flatten()?;
+        // Collapse whitespace/newlines into a single line.
+        let mut text: String = note.content.split_whitespace().collect::<Vec<_>>().join(" ");
+        if text.chars().count() > MAX_CHARS {
+            text = text.chars().take(MAX_CHARS).collect::<String>();
+            text.push('…');
+        }
+        Some(format!("- (w:{:.2}) {}\n", weight, text))
+    }
+
     /// Build persona context string for injection into additionalContext.
     async fn build_persona_context(
         &self,
@@ -270,22 +289,43 @@ impl SkillActivationHook {
             }
         };
 
+        // Real energy comes from the Persona node, not the subgraph stats. The
+        // previous placeholder (stats.freshness) is why hooks always reported
+        // "energy: 0.00". Fetch it so we can both display it and gate on it.
+        let energy = self
+            .graph_store
+            .get_persona(persona_id)
+            .await
+            .ok()
+            .flatten()
+            .map(|p| p.energy)
+            .unwrap_or(0.0);
+
+        // Skip personas that are effectively dead AND barely relevant to the
+        // current files — injecting them only adds low-signal noise. A persona
+        // that is either energetic OR strongly weighted to the scope is kept.
+        if energy < 0.01 && weight < 0.10 {
+            debug!(
+                persona_id = %persona_id,
+                energy,
+                weight,
+                "Skipping dead/low-relevance persona in hook injection"
+            );
+            return None;
+        }
+
         let mut ctx = format!(
             "## 🎭 Persona: {} (energy: {:.2}, weight: {:.2})\n",
-            persona_name,
-            // We don't have energy in subgraph, use a placeholder from stats
-            subgraph.stats.freshness,
-            weight
+            persona_name, energy, weight
         );
 
-        // Top notes (by weight, max 5)
+        // Top notes (by weight, max 5) — inject CONTENT, not bare ids.
         if !subgraph.notes.is_empty() {
             ctx.push_str("**Knowledge notes:**\n");
             for rel in subgraph.notes.iter().take(5) {
-                ctx.push_str(&format!(
-                    "- [note:{}] (w:{:.2})\n",
-                    rel.entity_id, rel.weight
-                ));
+                if let Some(line) = self.note_snippet(&rel.entity_id, rel.weight).await {
+                    ctx.push_str(&line);
+                }
             }
         }
 
@@ -307,15 +347,17 @@ impl SkillActivationHook {
                 ctx.push_str("\n**Related personas (via SYNAPSE links):**\n");
                 for (linked_id, linked_name, syn_weight) in linked.iter().take(2) {
                     ctx.push_str(&format!("- {} (synapse: {:.2})\n", linked_name, syn_weight));
-                    // Load top 3 notes from linked persona
+                    // Load top 3 notes from linked persona — content, not ids.
                     if let Ok(linked_subgraph) =
                         self.graph_store.get_persona_subgraph(*linked_id).await
                     {
                         for note_rel in linked_subgraph.notes.iter().take(3) {
-                            ctx.push_str(&format!(
-                                "  - [note:{}] (w:{:.2})\n",
-                                note_rel.entity_id, note_rel.weight
-                            ));
+                            if let Some(line) =
+                                self.note_snippet(&note_rel.entity_id, note_rel.weight).await
+                            {
+                                ctx.push_str("  ");
+                                ctx.push_str(&line);
+                            }
                         }
                     }
                 }
@@ -323,10 +365,10 @@ impl SkillActivationHook {
             _ => {}
         }
 
-        // Truncate to ~2000 chars for additionalContext budget
-        if ctx.len() > 2000 {
-            ctx.truncate(1996);
-            ctx.push_str("...\n");
+        // Truncate to ~2000 chars for additionalContext budget (char-safe).
+        if ctx.chars().count() > 2000 {
+            ctx = ctx.chars().take(1996).collect::<String>();
+            ctx.push_str("…\n");
         }
 
         Some(ctx)

--- a/src/neo4j/impl_graph_store.rs
+++ b/src/neo4j/impl_graph_store.rs
@@ -1851,6 +1851,16 @@ impl GraphStore for Neo4jClient {
             .await
     }
 
+    async fn semantic_anchor_note(
+        &self,
+        note_id: Uuid,
+        project_id: Uuid,
+        min_similarity: f64,
+    ) -> anyhow::Result<usize> {
+        self.semantic_anchor_note(note_id, project_id, min_similarity)
+            .await
+    }
+
     async fn get_notes_for_entity(
         &self,
         entity_type: &EntityType,

--- a/src/neo4j/mock.rs
+++ b/src/neo4j/mock.rs
@@ -5653,6 +5653,15 @@ impl GraphStore for MockGraphStore {
         Ok(0)
     }
 
+    async fn semantic_anchor_note(
+        &self,
+        _note_id: Uuid,
+        _project_id: Uuid,
+        _min_similarity: f64,
+    ) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn get_notes_for_entity(
         &self,
         entity_type: &EntityType,

--- a/src/neo4j/models.rs
+++ b/src/neo4j/models.rs
@@ -1304,6 +1304,12 @@ pub struct DeepMaintenanceReport {
     pub stale_notes_flagged: usize,
     /// Number of stuck tasks identified (in_progress > 48h)
     pub stuck_tasks_found: usize,
+    /// Number of note→entity LINKED_TO relations (re)created by knowledge reconstruction
+    #[serde(default)]
+    pub notes_relinked: usize,
+    /// Number of decision→entity AFFECTS relations (re)created by knowledge reconstruction
+    #[serde(default)]
+    pub affects_created: usize,
     /// Recommendations generated
     pub recommendations: Vec<String>,
 }

--- a/src/neo4j/note.rs
+++ b/src/neo4j/note.rs
@@ -659,6 +659,63 @@ impl Neo4jClient {
         Ok(total)
     }
 
+    /// Semantically anchor a SINGLE note to the most similar files in its
+    /// project, using the note's own embedding against the `file_embedding_index`
+    /// vector index. Used as a creation-time fallback when content-based
+    /// anchoring found no file paths in the note text — this is what keeps
+    /// "concept" notes (e.g. "always validate input") from becoming orphans.
+    ///
+    /// Creates LINKED_TO with `propagation_source = 'semantic_creation'` for the
+    /// top-K matches above `min_similarity`. Idempotent (skips existing links).
+    /// Returns the number of links created. No-op if the note has no embedding.
+    pub async fn semantic_anchor_note(
+        &self,
+        note_id: Uuid,
+        project_id: Uuid,
+        min_similarity: f64,
+    ) -> Result<usize> {
+        let q = query(
+            r#"
+            MATCH (n:Note {id: $note_id})
+            WHERE n.embedding IS NOT NULL
+            CALL db.index.vector.queryNodes('file_embedding_index', $k, n.embedding)
+            YIELD node AS f, score
+            WHERE score > $min_similarity
+              AND f.project_id = $project_id
+              AND NOT (n)-[:LINKED_TO]->(f)
+            MERGE (n)-[r:LINKED_TO]->(f)
+            ON CREATE SET
+                r.propagated = true,
+                r.propagation_source = 'semantic_creation',
+                r.similarity_score = score,
+                r.last_verified = datetime()
+            RETURN count(r) AS cnt
+            "#,
+        )
+        .param("note_id", note_id.to_string())
+        .param("k", 3i64)
+        .param("min_similarity", min_similarity)
+        .param("project_id", project_id.to_string());
+
+        let mut created = 0usize;
+        if let Ok(mut result) = self.graph.execute(q).await {
+            if let Ok(Some(row)) = result.next().await {
+                created = row.get::<i64>("cnt").unwrap_or(0) as usize;
+            }
+        }
+
+        if created > 0 {
+            tracing::debug!(
+                %note_id,
+                %project_id,
+                links_created = created,
+                "Semantic-anchored note to similar files (creation fallback)"
+            );
+        }
+
+        Ok(created)
+    }
+
     // ================================================================
     // High-Level Entity Propagation (FeatureGraph, Skill, Protocol)
     // ================================================================

--- a/src/neo4j/note.rs
+++ b/src/neo4j/note.rs
@@ -1332,6 +1332,9 @@ impl Neo4jClient {
         //   5. Scar penalty: (1 - scar_intensity * 0.5)
         //      Notes with high scar_intensity (from past invalidations) are de-prioritized.
         //      Max penalty = 50% score reduction at scar_intensity=1.0.
+        //   6. Energy factor: (0.4 + energy * 0.6)
+        //      Low-energy ("dead") notes are de-prioritized but never zeroed, so a
+        //      stale-but-relevant note still surfaces below a fresh equivalent.
         //
         // Relation weights (defined in Cypher CASE):
         //   CONTAINS=1.0, IMPORTS=1.0, CALLS=0.9, IMPLEMENTS_TRAIT=0.85,
@@ -1377,7 +1380,8 @@ impl Neo4jClient {
                  END AS path_rel_weight
             WITH n, source, distance, path_names, rel_types, avg_path_pagerank, path_rel_weight, hop_weights,
                  (1.0 / (distance + 1)) * importance_weight * (1.0 + avg_path_pagerank * 5.0) * path_rel_weight
-                 * (1.0 - COALESCE(n.scar_intensity, 0.0) * 0.5) AS score
+                 * (1.0 - COALESCE(n.scar_intensity, 0.0) * 0.5)
+                 * (0.4 + COALESCE(n.energy, 0.5) * 0.6) AS score
             WHERE score >= $min_score
             RETURN DISTINCT n, score, coalesce(source.name, source.path, source.id) AS source_entity,
                    path_names, distance, avg_path_pagerank,

--- a/src/neo4j/traits.rs
+++ b/src/neo4j/traits.rs
@@ -1445,6 +1445,16 @@ pub trait GraphStore: Send + Sync {
         min_similarity: f64,
     ) -> Result<usize>;
 
+    /// Semantically anchor a single note to its most similar project files
+    /// (creation-time fallback for notes with no file paths in their content).
+    /// Returns the number of LINKED_TO relations created.
+    async fn semantic_anchor_note(
+        &self,
+        note_id: Uuid,
+        project_id: Uuid,
+        min_similarity: f64,
+    ) -> Result<usize>;
+
     /// Unlink a note from an entity
     async fn unlink_note_from_entity(
         &self,

--- a/src/notes/manager.rs
+++ b/src/notes/manager.rs
@@ -282,6 +282,27 @@ impl NoteManager {
                             anchors = count,
                             "Auto-anchor: created file anchors from content"
                         );
+                    } else if let Some(pid) = note_clone.project_id {
+                        // Content mentioned no file paths → fall back to semantic
+                        // anchoring against the note's embedding so "concept" notes
+                        // don't become graph orphans. The embedding was awaited
+                        // before this task was spawned, so it is available here.
+                        match neo4j.semantic_anchor_note(note_clone.id, pid, 0.7).await {
+                            Ok(n) if n > 0 => tracing::debug!(
+                                note_id = %note_clone.id,
+                                anchors = n,
+                                "Auto-anchor: created semantic anchors (content had no file paths)"
+                            ),
+                            Ok(_) => tracing::debug!(
+                                note_id = %note_clone.id,
+                                "Auto-anchor: no content or semantic anchor found"
+                            ),
+                            Err(e) => tracing::warn!(
+                                note_id = %note_clone.id,
+                                error = %e,
+                                "Auto-anchor: semantic fallback failed"
+                            ),
+                        }
                     }
                 }
                 Err(e) => {

--- a/src/skills/maintenance.rs
+++ b/src/skills/maintenance.rs
@@ -661,8 +661,38 @@ pub async fn deep_maintenance(
     // 4. Identify stuck tasks (in_progress for too long)
     let stuck_tasks_found = count_stuck_tasks(graph_store, project_id).await;
 
+    // 4b. Reconstruct knowledge links — re-anchor orphan notes/decisions to code
+    // entities. This is the healing step that prevents orphans from persisting
+    // across maintenance cycles (notes/decisions linked back to files via
+    // LINKED_TO / AFFECTS, plus structural + semantic propagation). Non-fatal.
+    let (notes_relinked, affects_created) =
+        match crate::skills::activation::reconstruct_knowledge_links(graph_store, project_id).await
+        {
+            Ok(report) => {
+                info!(
+                    project_id = %project_id,
+                    notes_linked = report.notes_linked,
+                    affects_created = report.affects_created,
+                    structural = report.structural_propagated,
+                    semantic = report.semantic_linked,
+                    "Knowledge reconstruction during deep maintenance complete"
+                );
+                (report.notes_linked, report.affects_created)
+            }
+            Err(e) => {
+                warn!(error = %e, "Knowledge reconstruction failed during deep maintenance");
+                (0, 0)
+            }
+        };
+
     // 5. Build recommendations
     let mut recommendations = stagnation.recommendations.clone();
+    if notes_relinked > 0 || affects_created > 0 {
+        recommendations.push(format!(
+            "Knowledge reconstruction re-anchored {} note link(s) and {} decision AFFECTS link(s).",
+            notes_relinked, affects_created
+        ));
+    }
     if stale_notes_flagged > 0 {
         recommendations.push(format!(
             "{} notes have high staleness — review with note(action: \"get_needing_review\").",
@@ -690,6 +720,8 @@ pub async fn deep_maintenance(
         maintenance: maintenance_json,
         stale_notes_flagged,
         stuck_tasks_found,
+        notes_relinked,
+        affects_created,
         recommendations,
     })
 }


### PR DESCRIPTION
## Why

Diagnosed from the live PO graph (`get_health_dashboard` / `get_knowledge_gaps`) + code:
- **Under-linked graph**: 100 orphan notes persisted *despite* maintenance running, because `deep_maintenance` never rebuilt knowledge links. `decision_coverage` is critical (2.9%).
- **Low-signal context injection**: the propagation score ignored `note.energy`, and the persona hook reported a *placeholder* energy (always `0.00`) while injecting bare `[note:uuid]` ids with no content — so the agent received unresolved references instead of knowledge.

## What

**1. Pipeline — `deep_maintenance` now heals links** (`skills/maintenance.rs`, `neo4j/models.rs`)
Calls `reconstruct_knowledge_links` in-process (content + semantic + structural propagation), avoiding the MCP/HTTP timeout of the admin path. Counts surfaced in `DeepMaintenanceReport`.

**2. Ranking — energy factor in `get_propagated_notes`** (`neo4j/note.rs`)
Bounded factor `(0.4 + energy*0.6)`: dead notes are de-prioritized, never zeroed.

**3. Persona hook injection** (`chat/skill_hook.rs`)
Reports **real** persona energy (via `get_persona`), gates out dead + low-relevance personas, and injects truncated note **content** snippets instead of bare ids.

**4. Prevention — semantic anchoring at note creation** (`notes/manager.rs`, `neo4j/{note,traits,impl_graph_store,mock}.rs`)
New `GraphStore::semantic_anchor_note`: when content-based auto-anchor finds no file paths, fall back to the note's embedding vs `file_embedding_index` to link the top-K similar files. Stops "concept" notes from becoming orphans at the source.

## Tests
`cargo check --lib` ✅, `cargo clippy` ✅ (pre-push), and unit tests: notes 111 · activation 101 · maintenance 49 · skill_hook 30 — all pass.

## Note
Existing 100 orphans are resorbed once a build with this change runs `deep_maintenance` (in-process semantic propagation). `decision_coverage` remains a separate follow-up (enforce decision AFFECTS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)