### PR TITLE
feat(mcp): expose note-embedding backfill as admin action

### DIFF
--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -625,6 +625,8 @@ impl ToolHandler {
             ("admin", "backfill_synapses") => "backfill_synapses",
             ("admin", "reindex_decisions") => "reindex_decisions",
             ("admin", "backfill_decision_embeddings") => "backfill_decision_embeddings",
+            ("admin", "backfill_note_embeddings") => "backfill_note_embeddings",
+            ("admin", "backfill_note_embeddings_status") => "backfill_note_embeddings_status",
             ("admin", "backfill_touches") => "backfill_touches",
             ("admin", "backfill_discussed") => "backfill_discussed",
             ("admin", "update_fabric_scores") => "update_fabric_scores",
@@ -2799,6 +2801,22 @@ impl ToolHandler {
                 let result = http
                     .post("/api/admin/backfill-decision-embeddings", &json!({}))
                     .await?;
+                Ok(Some(result))
+            }
+
+            "backfill_note_embeddings" => {
+                let mut body = serde_json::Map::new();
+                if let Some(bs) = args.get("batch_size").and_then(|v| v.as_u64()) {
+                    body.insert("batch_size".to_string(), json!(bs));
+                }
+                let result = http
+                    .post("/api/admin/backfill-embeddings", &Value::Object(body))
+                    .await?;
+                Ok(Some(result))
+            }
+
+            "backfill_note_embeddings_status" => {
+                let result = http.get("/api/admin/backfill-embeddings/status").await?;
                 Ok(Some(result))
             }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -338,6 +338,8 @@ pub fn resolve_legacy_alias(name: &str) -> Option<(&'static str, &'static str)> 
         "backfill_synapses" => Some(("admin", "backfill_synapses")),
         "reindex_decisions" => Some(("admin", "reindex_decisions")),
         "backfill_decision_embeddings" => Some(("admin", "backfill_decision_embeddings")),
+        "backfill_note_embeddings" => Some(("admin", "backfill_note_embeddings")),
+        "backfill_note_embeddings_status" => Some(("admin", "backfill_note_embeddings_status")),
         "detect_skills" => Some(("admin", "detect_skills")),
         "detect_skill_fission" => Some(("admin", "detect_skill_fission")),
         "detect_skill_fusion" => Some(("admin", "detect_skill_fusion")),
@@ -993,13 +995,13 @@ fn analysis_profile_tool() -> ToolDefinition {
 fn admin_tool() -> ToolDefinition {
     ToolDefinition {
         name: "admin".to_string(),
-        description: "Admin operations. Actions: sync_directory, start_watch, stop_watch, watch_status, meilisearch_stats, delete_meilisearch_orphans, cleanup_cross_project_calls, cleanup_builtin_calls, migrate_calls_confidence, cleanup_sync_data, update_staleness_scores, update_energy_scores, search_neurons, reinforce_neurons, decay_synapses, backfill_synapses, reindex_decisions, backfill_decision_embeddings, backfill_touches, backfill_discussed, update_fabric_scores, bootstrap_knowledge_fabric, reinforce_isomorphic, detect_skills, detect_skill_fission, detect_skill_fusion, heal_scars, consolidate_memory, detect_stagnation, deep_maintenance, analyze_runner_feedback, install_hooks".to_string(),
+        description: "Admin operations. Actions: sync_directory, start_watch, stop_watch, watch_status, meilisearch_stats, delete_meilisearch_orphans, cleanup_cross_project_calls, cleanup_builtin_calls, migrate_calls_confidence, cleanup_sync_data, update_staleness_scores, update_energy_scores, search_neurons, reinforce_neurons, decay_synapses, backfill_synapses, reindex_decisions, backfill_decision_embeddings, backfill_note_embeddings, backfill_note_embeddings_status, backfill_touches, backfill_discussed, update_fabric_scores, bootstrap_knowledge_fabric, reinforce_isomorphic, detect_skills, detect_skill_fission, detect_skill_fusion, heal_scars, consolidate_memory, detect_stagnation, deep_maintenance, analyze_runner_feedback, install_hooks".to_string(),
         input_schema: InputSchema {
             schema_type: "object".to_string(),
             properties: Some(json!({
                 "action": {
                     "type": "string",
-                    "enum": ["sync_directory", "start_watch", "stop_watch", "watch_status", "meilisearch_stats", "delete_meilisearch_orphans", "cleanup_cross_project_calls", "cleanup_builtin_calls", "migrate_calls_confidence", "cleanup_sync_data", "update_staleness_scores", "update_energy_scores", "search_neurons", "reinforce_neurons", "decay_synapses", "backfill_synapses", "reindex_decisions", "backfill_decision_embeddings", "backfill_touches", "backfill_discussed", "update_fabric_scores", "bootstrap_knowledge_fabric", "reinforce_isomorphic", "detect_skills", "detect_skill_fission", "detect_skill_fusion", "maintain_skills", "auto_anchor_notes", "reconstruct_knowledge", "heal_scars", "consolidate_memory", "detect_stagnation", "deep_maintenance", "seed_prompt_fragments", "analyze_runner_feedback", "install_hooks"],
+                    "enum": ["sync_directory", "start_watch", "stop_watch", "watch_status", "meilisearch_stats", "delete_meilisearch_orphans", "cleanup_cross_project_calls", "cleanup_builtin_calls", "migrate_calls_confidence", "cleanup_sync_data", "update_staleness_scores", "update_energy_scores", "search_neurons", "reinforce_neurons", "decay_synapses", "backfill_synapses", "reindex_decisions", "backfill_decision_embeddings", "backfill_note_embeddings", "backfill_note_embeddings_status", "backfill_touches", "backfill_discussed", "update_fabric_scores", "bootstrap_knowledge_fabric", "reinforce_isomorphic", "detect_skills", "detect_skill_fission", "detect_skill_fusion", "maintain_skills", "auto_anchor_notes", "reconstruct_knowledge", "heal_scars", "consolidate_memory", "detect_stagnation", "deep_maintenance", "seed_prompt_fragments", "analyze_runner_feedback", "install_hooks"],
                     "description": "Operation to perform"
                 },
                 "path": {"type": "string", "description": "Directory path (sync_directory/start_watch)"},


### PR DESCRIPTION
## Why
Follow-up to #361. Diagnosis on the live PO graph showed 100 legacy orphan notes that **cannot** be semantically anchored because they have no embedding — and there was **no way to backfill note embeddings from the agent**: the REST endpoint `POST /api/admin/backfill-embeddings` (→ `NoteManager::backfill_embeddings`) existed, but only `backfill_decision_embeddings` was wired into the `admin` MCP mega-tool.

## What
Expose the existing capability via two MCP admin actions (proxy to the existing REST endpoints — no new business logic):
- `admin backfill_note_embeddings` (optional `batch_size`) → starts the background backfill job
- `admin backfill_note_embeddings_status` → polls `BackfillJobState` progress

Wiring only:
- `mcp/tools.rs`: schema description + action enum + resolve map
- `mcp/handlers.rs`: action normalize map + two execution arms

## Unblocks
Once deployed, an agent can run `backfill_note_embeddings` → then `deep_maintenance`/`reconstruct_knowledge` semantic propagation (see #361) can finally anchor the legacy orphan notes.

## Tests
`cargo check` ✅, `cargo clippy` ✅, `cargo test --lib mcp::` → 469 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)